### PR TITLE
Add root store with middleware.

### DIFF
--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -7,10 +7,9 @@ import { Provider } from 'react-redux';
 
 import App from './components/App.jsx';
 
-//import reducers from './reducers/reducers.js';
 import Home from './components/Home.jsx';
 import Teachers from './components/Teachers.jsx';
-import TeachersDashboard from './components/TeachersDashboard.jsx'
+import TeachersDashboard from './components/TeachersDashboard.jsx';
 import MapExplorer from './components/MapExplorer.jsx';
 import Styles from './styles/main.styl';
 

--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -3,20 +3,23 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Router, Route, IndexRoute } from 'react-router';
-import { createStore } from 'redux'
-import { Provider } from 'react-redux'
+import { Provider } from 'react-redux';
 
 import App from './components/App.jsx';
 
-import reducers from './reducers/reducers.js';
+//import reducers from './reducers/reducers.js';
 import Home from './components/Home.jsx';
 import Teachers from './components/Teachers.jsx';
 import TeachersDashboard from './components/TeachersDashboard.jsx'
 import MapExplorer from './components/MapExplorer.jsx';
 import Styles from './styles/main.styl';
 
+import configureStore from './store/configureStore';
+
+const store = configureStore();
+
 window.React = React;
-let store = createStore(reducers)
+
 ReactDOM.render(
   <Provider store={store}>
     <Router>

--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -3,24 +3,13 @@ import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Route, IndexRoute } from 'react-router';
-<<<<<<< HEAD
+
 import { Provider } from 'react-redux';
-
-import App from './components/App.jsx';
-
-import Home from './components/Home.jsx';
-import Teachers from './components/Teachers.jsx';
-import TeachersDashboard from './components/TeachersDashboard.jsx';
-=======
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-
-import reducers from './reducers/reducers.js';
 
 import App from './components/App.jsx';
 import Home from './components/Home.jsx';
 import LoginHandler from './components/LoginHandler.jsx';
->>>>>>> master
+
 import MapExplorer from './components/MapExplorer.jsx';
 import Teachers from './components/Teachers.jsx';
 import TeachersDashboard from './components/TeachersDashboard.jsx';
@@ -32,10 +21,7 @@ import configureStore from './store/configureStore';
 const store = configureStore();
 
 window.React = React;
-<<<<<<< HEAD
-=======
-let store = createStore(reducers);
->>>>>>> master
+
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,18 +1,17 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-//import rootReducer from '../reducers';
 import rootReducer from '../reducers/reducers';
-const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
+const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore);
 
 export default function configureStore(initialState) {
-  const store = createStoreWithMiddleware(rootReducer, initialState)
+  const store = createStoreWithMiddleware(rootReducer, initialState);
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers/reducers', () => {
-      const nextRootReducer = require('../reducers/reducers')
-      store.replaceReducer(nextRootReducer)
-    })
+      const nextRootReducer = require('../reducers/reducers');
+      store.replaceReducer(nextRootReducer);
+    });
   }
-  return store
+  return store;
 }

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,0 +1,18 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+//import rootReducer from '../reducers';
+import rootReducer from '../reducers/reducers';
+const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
+
+export default function configureStore(initialState) {
+  const store = createStoreWithMiddleware(rootReducer, initialState)
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers/reducers', () => {
+      const nextRootReducer = require('../reducers/reducers')
+      store.replaceReducer(nextRootReducer)
+    })
+  }
+  return store
+}


### PR DESCRIPTION
This is the first of a series of PRs intended to make network requests (fetching classrooms, login, etc) to work with redux-thunk middleware. The point of using a middleware layer is that we can dispatch other things other than actions, e.g. functions, to delay the execution of an action. 
Here `applyMiddleware` makes sure that the middleware is available in the actions dispatch method.
Webpack's Hot Module Replacement makes sure modules (reducers in this case) are kept updated.
