### PR TITLE
Load polyfill via webpack

### DIFF
--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -1,5 +1,3 @@
-import 'babel-polyfill';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Route, IndexRoute } from 'react-router';

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -11,6 +11,7 @@ var bootstrap = require('bootstrap-styl');
 module.exports = {
 
   entry: [
+    'babel-polyfill',
     path.join(__dirname, 'src/Index.jsx'),
   ],
 


### PR DESCRIPTION
Load the babel-polyfill package by webpack only, fix #43 
