### PR TITLE
Hotfix: Absolute http:// links to CartoDB JS files replaced with //

### DIFF
--- a/src/containers/MapExplorer.jsx
+++ b/src/containers/MapExplorer.jsx
@@ -17,10 +17,10 @@ export default React.createClass({
     console.log('render()');
     return (
       <div className='map-explorer'>
-        <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+        <link rel="stylesheet" href="//libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
         <div ref="mapVisuals" id="mapVisuals" className="map-visuals"></div>
         <div ref="mapControls" className="map-controls">
-          <Script src={'http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js'}>{
+          <Script src={'//libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js'}>{
             ({done}) => !done ? <div className="message">Map Explorer is loading...</div> : this.initMapExplorer()
           }</Script>
           <div className="inputRow">


### PR DESCRIPTION
Issue: On the preview server, things go nuts if there's a request for an external file that uses http:// instead of https://
Action: Replaced all external JS calls from http:// to the relative //.

@simoneduca , here we go!
