### PR TITLE
Hotfix: Allow HTTPS support for CartoDB.

### DIFF
--- a/src/containers/MapExplorer.jsx
+++ b/src/containers/MapExplorer.jsx
@@ -17,10 +17,10 @@ export default React.createClass({
     console.log('render()');
     return (
       <div className='map-explorer'>
-        <link rel="stylesheet" href="//libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+        <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
         <div ref="mapVisuals" id="mapVisuals" className="map-visuals"></div>
         <div ref="mapControls" className="map-controls">
-          <Script src={'//libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js'}>{
+          <Script src={'https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js'}>{
             ({done}) => !done ? <div className="message">Map Explorer is loading...</div> : this.initMapExplorer()
           }</Script>
           <div className="inputRow">


### PR DESCRIPTION
So `hotfix-mapexplorer-https` in #52 didn't work for https://. This should work instead, using the following (correct, HTTPS-enabled) URLs:

https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css
https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js

@simoneduca , ready to roll.
