### PR TITLE
Fixes issue #93 by checking if an object reference is `undefined`

### DIFF
--- a/src/actions/classrooms.js
+++ b/src/actions/classrooms.js
@@ -39,7 +39,8 @@ export function createClassroom(name, subject, school, description) {
     .then(json => {
       dispatch({
         type: types.CREATE_CLASSROOM_SUCCESS,
-        data: json.data
+        data: json.data,
+        members: json.included,
       });
       browserHistory.push(`/teachers/classrooms/${json.data.id}`);
     })

--- a/src/containers/Classrooms.jsx
+++ b/src/containers/Classrooms.jsx
@@ -8,11 +8,11 @@ import ClassroomsSidebar from '../presentational/ClassroomsSidebar.jsx';
 class Classrooms extends Component {
 
   componentDidMount() {
-    if (!this.props.classrooms.data.length && !this.props.classrooms.loading) {
+    if (!this.props.classrooms.members.length && !this.props.classrooms.data.length && !this.props.classrooms.loading) {
       this.props.dispatch(fetchClassrooms());
     }
   }
-  
+
   getChildContext() {
     return {
       classrooms: this.props.classrooms
@@ -40,13 +40,14 @@ Classrooms.propTypes = {
 Classrooms.defaultProps = {
   classrooms: {
     data: [],
-    loading: false,
     error: false,
+    loading: false,
+    members: [],
   }
 };
 
 Classrooms.childContextTypes = {
-  classrooms: PropTypes.object
+  classrooms: PropTypes.object.isRequired
 };
 
 function mapStateToProps(state) {

--- a/src/presentational/ClassroomsOverview.jsx
+++ b/src/presentational/ClassroomsOverview.jsx
@@ -2,8 +2,8 @@ import { PropTypes } from 'react';
 
 const ClassroomsOverview = (props, context) => (
   <div>
-    <p>{(context.classrooms.data) ? context.classrooms.data.length : 0} Classrooms</p>
-    <p>{(context.classrooms.members) ? context.classrooms.members.length : 0} Students</p>
+    <p>{context.classrooms.data.length} Classrooms</p>
+    <p>{context.classrooms.members.length} Students</p>
   </div>
 );
 

--- a/src/presentational/ClassroomsOverview.jsx
+++ b/src/presentational/ClassroomsOverview.jsx
@@ -2,8 +2,8 @@ import { PropTypes } from 'react';
 
 const ClassroomsOverview = (props, context) => (
   <div>
-    <p>{context.classrooms.data.length} Classrooms.</p>
-    <p>{context.classrooms.members.length} Students</p>
+    <p>{(context.classrooms.data) ? context.classrooms.data.length : 0} Classrooms</p>
+    <p>{(context.classrooms.members) ? context.classrooms.members.length : 0} Students</p>
   </div>
 );
 

--- a/src/presentational/ClassroomsOverview.jsx
+++ b/src/presentational/ClassroomsOverview.jsx
@@ -8,7 +8,7 @@ const ClassroomsOverview = (props, context) => (
 );
 
 ClassroomsOverview.contextTypes = {
-  classrooms: PropTypes.object
+  classrooms: PropTypes.object.isRequired
 }
 
 export {ClassroomsOverview as default}

--- a/src/reducers/classrooms.js
+++ b/src/reducers/classrooms.js
@@ -18,9 +18,9 @@ export function classrooms(state = initialState, action) {
     case types.RECEIVE_CLASSROOMS:
       return Object.assign({}, state, {
         loading: false,
-        data: action.data,
+        data: action.data || [],
         error: action.error,
-        members: action.members
+        members: action.members || [],
       });
       case types.CREATE_CLASSROOM:
       return Object.assign({}, state, {
@@ -32,6 +32,7 @@ export function classrooms(state = initialState, action) {
         loading: false,
         data: newlist,
         error: false,
+        members: action.members || [],
       });
     case types.CREATE_CLASSROOM_ERROR:
       return Object.assign({}, state, {


### PR DESCRIPTION
Fixes #93 

Issue: On certain Zooniverse accounts, accessing the Teachers->Classrooms causes the app to crash with the error message: `Uncaught (in promise) TypeError: Cannot read property 'remove' of undefined(…)`

Analysis: The value of `context.classrooms.members` is undefined in `ClassroomsOverview.jsx`. This has been most notable on Zooniverse accounts that have never crated any Classrooms or invited students before (e.g. Grant's)

Solution: the code now checks if the potentially undefined variable is, in fact, defined before proceeding to use it.

Status: Fix works successfully on localhost using Shaun's and Grant's accounts.
**HOWEVER**: I have been unable to test what happens on accounts that _do_ have existent classrooms/students. @simoneduca / @eatyourgreens , if your account already has (say) 15 students before and the ClassroomsOverview shows "15 Students", this is great. However, if you see "0 Students", then the issue is rooted in `context.classrooms` not receiving `member` properly.

Actions: Pending review.
