### PR TITLE
Fixes for Issues #115, #119, #120, #122 - Better CSV labelling and handling plus HTTP stuff

### DIFF
--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -18,12 +18,12 @@
   "baseLayers": [
     {
       "name": "Terrain",
-      "url": "http://{s}.tile.thunderforest.com/landscape/{z}/{x}/{y}.png",
+      "url": "//{s}.tile.thunderforest.com/landscape/{z}/{x}/{y}.png",
       "attribution": "&copy; <a href=\"http://www.opencyclemap.org\">OpenCycleMap</a>, &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
     },
     {
       "name": "Satellite",
-      "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
       "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
     }
   ],

--- a/src/containers/MapExplorer-SelectorPanel.jsx
+++ b/src/containers/MapExplorer-SelectorPanel.jsx
@@ -285,7 +285,7 @@ export default class SelectorPanel extends React.Component {
     this.setState({
       downloadDialog: {
         status: DialogScreen.DIALOG_ACTOVE,
-        message: 'Preparing CSV file...',
+        message: 'Preparing data file...',
         data: null
     }});
     
@@ -323,7 +323,7 @@ export default class SelectorPanel extends React.Component {
         this.setState({
           downloadDialog: {
             status: DialogScreen.DIALOG_ACTIVE,
-            message: 'CSV ready!',
+            message: 'Data file ready!',
             data: data
         }});
       })

--- a/src/presentational/DialogScreen-Download.jsx
+++ b/src/presentational/DialogScreen-Download.jsx
@@ -6,6 +6,8 @@ export default class DialogScreen_DownloadCSV extends DialogScreen {
   constructor(props) {
     super(props);
     this.downloadCsv = this.downloadCsv.bind(this);
+    this.blobbifyCsvData = this.blobbifyCsvData.bind(this);
+    this.generateFilename = this.generateFilename.bind(this);
   }
 
   render() {
@@ -19,7 +21,11 @@ export default class DialogScreen_DownloadCSV extends DialogScreen {
           : null}
           
           {(this.props.data)
-          ? <div><a className="btn" onClick={this.downloadCsv}>Download</a></div>
+          ? <div><a className="btn" href={window.URL.createObjectURL(this.blobbifyCsvData())} download={this.generateFilename()} onClick={this.downloadCsv}>Download</a></div>
+          : null}
+          
+          {(this.props.data)
+          ? <div className="note">(Depending on your computer setup, you may need to right-click on the link above and choose "Save As", then open the downloaded file in Excel.)</div>
           : null}
           
         </div>
@@ -28,18 +34,34 @@ export default class DialogScreen_DownloadCSV extends DialogScreen {
     );
   }
 
+  //NOTE: The onClick=downloadCsv() feature is required because, by default,
+  //React 'eats' the click event of <a download>s which would otherwise trigger
+  //a native browser download event.
   downloadCsv(e) {
     if (this.props.data) {
-      let dataBlob = new Blob([this.props.data], {type: 'text/csv'});
-      let timeString = new Date();
-      timeString =
-        timeString.getDate() +
-        ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][timeString.getMonth()] +
-        timeString.getFullYear();
-      saveAs(dataBlob, 'wildcam-'+timeString+'.csv');
+      let dataBlob = this.blobbifyCsvData();
+      let filename = this.generateFilename();
+      saveAs(dataBlob, filename);
       this.closeMe();
     } else {
       console.error('Download CSV Error: no CSV');
     }
+  }
+  
+  blobbifyCsvData() {
+    if (this.props.data) {
+      let dataBlob = new Blob([this.props.data], {type: 'text/csv'});
+      return dataBlob;
+    }
+    return null;
+  }
+  
+  generateFilename(extension = '.csv') {
+    let timeString = new Date();
+    timeString =
+      timeString.getDate() +
+      ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][timeString.getMonth()] +
+      timeString.getFullYear();
+    return 'wildcam-' + timeString + extension;
   }
 }

--- a/src/presentational/DialogScreen-Download.jsx
+++ b/src/presentational/DialogScreen-Download.jsx
@@ -31,7 +31,12 @@ export default class DialogScreen_DownloadCSV extends DialogScreen {
   downloadCsv(e) {
     if (this.props.data) {
       let dataBlob = new Blob([this.props.data], {type: 'text/csv'});
-      saveAs(dataBlob, 'wildcam.csv');
+      let timeString = new Date();
+      timeString =
+        timeString.getDate() +
+        ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][timeString.getMonth()] +
+        timeString.getFullYear();
+      saveAs(dataBlob, 'wildcam-'+timeString+'.csv');
       this.closeMe();
     } else {
       console.error('Download CSV Error: no CSV');

--- a/src/styles/components/dialog-screen.styl
+++ b/src/styles/components/dialog-screen.styl
@@ -25,3 +25,8 @@
 
     > div
       text-align: center
+    
+    .note
+      color: #999
+      font-size: 0.8em
+      max-width: 20em


### PR DESCRIPTION
I return from my bug hunt with many trophies. Tiny, tiny trophies, but many of 'em.
- Fix #115: Map URLs now use `//url` instead of `http://url` to avoid "Mixed content" warnings.
- Fix #119: "Preparing CSV file" and "CSV file ready!" messages now replace "CSV file" with "data file"
- Fix #120: The CSV/data file previously downloaded as wildcam.csv; now it's downloaded with a more descriptive name like wildcam-23mar2016.csv. 
- Fix #122: When the CSV/data file is prepared, a little note is added telling users that _"Depending on your computer setup, you may need to right-click on the link above and choose "Save As", then open the downloaded file in Excel."_
- Misc: The Download link now has a DataURI (using `<a download href="data:...">`) _in addition to_ the Save() feature, which allows users to download via left-click-default or right-click-save-as
  - This stems from the issue that our React (or perhaps react-router) setup 'eats' standard click actions, preventing the intended default behaviour of `<a download href="data:...">`

Ready for review, @simoneduca and @eatyourgreens 
