### PR TITLE
Add Tutorial/Help pages for Teachers and Students

### DIFF
--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -16,6 +16,8 @@ import ClassroomsOverview from './presentational/ClassroomsOverview.jsx';
 import NewClassroomForm from './presentational/NewClassroomForm.jsx';
 import StudentOverview from './presentational/StudentOverview.jsx';
 import Resources from './presentational/Resources.jsx'
+import TutorialForTeachers from './presentational/Tutorial-Teachers.jsx'
+import TutorialForStudents from './presentational/Tutorial-Students.jsx'
 
 import LoginPromptPage from './presentational/LoginPromptPage.jsx';
 import ErrorPage from './presentational/ErrorPage.jsx';
@@ -45,6 +47,7 @@ oauth.init(panoptesAppId)
                 <Route path=":classroomId" component={Classroom} />
               </Route>
               <Route path="data" component={MapExplorer} />
+              <Route path="tutorial" component={TutorialForTeachers} />
               <Route path="resources" component={Resources} />
             </Route>
             <Route path="students" component={Students}>
@@ -54,6 +57,7 @@ oauth.init(panoptesAppId)
                 <Route path="join" component={JoinClassroom} />
               </Route>
               <Route path="data" component={MapExplorer} />
+              <Route path="tutorial" component={TutorialForStudents} />
             </Route>
             <Route path="login" component={LoginPromptPage} />
           </Route>

--- a/src/containers/Students.jsx
+++ b/src/containers/Students.jsx
@@ -26,6 +26,10 @@ Students.defaultProps = {
       to: '/students/data'
     },
     {
+      label: 'Tutorial',
+      to: '/students/tutorial'
+    },
+    {
       label: 'Feedback',
       to: 'https://docs.google.com/a/zooniverse.org/forms/d/1Cx4LDXevyqZZheB_EupVRxd7jCzpoH-m8j494cyNNfc/edit'
     }

--- a/src/containers/Teachers.jsx
+++ b/src/containers/Teachers.jsx
@@ -30,6 +30,10 @@ Teachers.defaultProps = {
       to: '/teachers/resources'
     },
     {
+      label: 'Tutorial',
+      to: '/teachers/tutorial'
+    },
+    {
       label: 'Feedback',
       to: 'https://docs.google.com/a/zooniverse.org/forms/d/1Cx4LDXevyqZZheB_EupVRxd7jCzpoH-m8j494cyNNfc/edit'
     }

--- a/src/presentational/Tutorial-Students.jsx
+++ b/src/presentational/Tutorial-Students.jsx
@@ -1,0 +1,45 @@
+const TutorialForStudents = (props) => (
+  <div className="admin-component tutorial">
+    <h1>Help For Explorers</h1>
+    <p>WildCam Lab is a tool for students to download and explore data from the WildCam Gorongosa trail cameras. Your instructor can invite you to join their classroom by sending you a link. You must register for a Zooniverse account to use this resource.</p>
+
+    <h2>Register for a Zooniverse account</h2>
+    <ul>
+      <li>Go to the Zooniverse home page <a href="https://www.zooniverse.org/">(https://www.zooniverse.org/)</a> and click the register link at the top right.</li>
+      <li>Create a user name and password, enter your email address and name, and agree to the privacy policy.</li>
+      <li>Click the register button.</li>
+    </ul>
+
+    <h2>Enter the WildCam Lab</h2>
+    <ul>
+      <li>Follow the link that your instructor sent you to join their classroom. Alternatively, go to the main page of the WildCam Lab <a href="https://learn.wildcamgorongosa.org">(https://learn.wildcamgorongosa.org)</a> and click the button for students. </li>
+      <li>If you are not yet logged in to Zooniverse, you will be prompted to log in.</li>
+    </ul>
+
+    <h2>View your classroom</h2>
+    <ul>
+      <li>Click the classroom tab to see the list of classrooms that you belong to.</li>
+    </ul>
+
+    <h2>Explore trail camera data</h2>
+    <ul>
+      <li>Click on the “Data” tab.</li>
+      <li>On the right, you will see a map with dots, each representing a trail camera. Orange dots represent cameras that have at least one photo that has been completely classified by citizen scientists. Black dots represent cameras that have taken photos, but those photos have not yet been classified. The size of the dots is relative to the number of photos that match your filter criteria.</li>
+      <li>Select options on the left to filter the data. Click the “Apply” button at the bottom to update the map.</li>
+      <li>When you select multiple species, the map will display all photos that have at least one of the species selected. For example, if you select baboons and impala, this will filter for photos that have either a baboon, an impala, or both.</li>
+      <li>To enter a date range, type the dates in this format: YYYY-MM-DD.</li>
+    </ul>
+
+    <h2>Download trail camera data</h2>
+    <ul>
+      <li>If you wish to download a spreadsheet of filtered data, select your filters and click “Apply.” Then click the “Download” button. A pop-up will appear that says “CSV ready!” Click “Download” and a CSV file will be automatically downloaded to your desktop or other destination folder. </li>
+      <li>If you wish to export a spreadsheet of the entire trail camera data set, do not apply any filters and simply click on the “Download” button.</li>
+      <li>Click “Download” and select the destination folder for the file. Click “Save.”</li>
+      <li>The downloaded file is in CSV (comma separated values) format. Files of this format can be opened in Microsoft Excel by double-clicking the file. If the file does not automatically open in Excel, open Excel, click File>Open, and select the CSV file from your computer. </li>
+      <li>If you wish to convert the CSV file to an Excel file (.xls), open the CSV file in Excel and click File>Save as. In the format dropdown, select Excel 97-2004 Workbook (.xls).</li>
+    </ul>
+
+  </div>
+);
+
+export {TutorialForStudents as default}

--- a/src/presentational/Tutorial-Teachers.jsx
+++ b/src/presentational/Tutorial-Teachers.jsx
@@ -1,0 +1,62 @@
+const TutorialForTeachers = (props) => (
+  <div className="admin-component tutorial">
+    <h1>Help For Educators</h1>
+    <p>WildCam Lab is a tool for students to download and explore data from the WildCam Gorongosa trail cameras. As an educator, you can set up private classrooms, invite students to join your classrooms, and filter and download data sets. All users (educators and students) must register for a Zooniverse account to use this resource.</p>
+
+    <h2>Register for a Zooniverse account</h2>
+    <ul>
+      <li>Go to the Zooniverse home page <a href="https://www.zooniverse.org/">(https://www.zooniverse.org/)</a> and click the register link at the top right.</li>
+      <li>Create a user name and password, enter your email address and name, and agree to the privacy policy.</li>
+      <li>Click the register button.</li>
+    </ul>
+
+    <h2>Enter the WildCam Lab</h2>
+    <ul>
+      <li>From the main page of the WildCam Lab <a href="https://learn.wildcamgorongosa.org">(https://learn.wildcamgorongosa.org)</a>, click the button for educators. </li>
+      <li>If you are not yet logged in to Zooniverse, you will be prompted to log in.</li>
+    </ul>
+
+    <h2>Set up a classroom</h2>
+    <ul>
+      <li>In the classroom tab, click on the “New” button next to classrooms.</li>
+      <li>Create a name for the classroom. This name is required and it will be the name that is displayed in your list of classrooms.</li>
+      <li>If the subject of your classroom is different from the classroom name, you may add it in the subject field.</li>
+      <li>Optionally, you can add the name of your school and a description of your classroom.</li>
+      <li>Click the submit button.</li>
+    </ul>
+
+    <h2>Invite students</h2>
+    <ul>
+      <li>After you create a new classroom, your classroom overview page will appear. Click the “Copy Link” button to copy the link.</li>
+      <li>Paste this link in an email to send to your students or post it on a class forum. Instruct students to register for a Zooniverse account before they click on this link.</li>
+    </ul>
+    
+    <h2>View students in your classroom</h2>
+    <ul>
+      <li>In the classroom tab, click on the classroom you are interested in. </li>
+      <li>Click on the “Students” tab to see a list of students who have joined that classroom.</li>
+    </ul>
+
+    <h2>Explore trail camera data</h2>
+    <ul>
+      <li>Click on the “Data” tab.</li>
+      <li>On the right, you will see a map with dots, each representing a trail camera. Orange dots represent cameras that have at least one photo that has been completely classified by citizen scientists. Black dots represent cameras that have taken photos, but those photos have not yet been classified. The size of the dots is relative to the number of photos that match your filter criteria.</li>
+      <li>Select options on the left to filter the data. Click the “Apply” button at the bottom to update the map.</li>
+      <li>When you select multiple species, the map will display all photos that have at least one of the species selected. For example, if you select baboons and impala, this will filter for photos that have either a baboon, an impala, or both.</li>
+      <li>To enter a date range, type the dates in this format: YYYY-MM-DD.</li>
+    </ul>
+
+    <h2>Download trail camera data</h2>
+    <ul>
+      <li>If you wish to download a spreadsheet of filtered data, select your filters and click “Apply.” Then click the “Download” button. A pop-up will appear that says “CSV ready!” Click “Download” and a CSV file will be automatically downloaded to your desktop or other destination folder. </li>
+      <li>If you wish to export a spreadsheet of the entire trail camera data set, do not apply any filters and simply click on the “Download” button.</li>
+      <li>Click “Download” and select the destination folder for the file. Click “Save.”</li>
+      <li>The downloaded file is in CSV (comma separated values) format. Files of this format can be opened in Microsoft Excel by double-clicking the file. If the file does not automatically open in Excel, open Excel, click File>Open, and select the CSV file from your computer. </li>
+      <li>If you wish to convert the CSV file to an Excel file (.xls), open the CSV file in Excel and click File>Save as. In the format dropdown, select Excel 97-2004 Workbook (.xls).</li>
+      <li>You can share data sets that you curate for students, or you can instruct students to explore the map, filter, and download data on their own.</li>
+    </ul>
+
+  </div>
+);
+
+export {TutorialForTeachers as default}

--- a/src/styles/components/tutorial.styl
+++ b/src/styles/components/tutorial.styl
@@ -1,0 +1,17 @@
+.tutorial
+  max-width: 60em
+  margin: auto
+
+  ul
+    text-indent: 0
+    
+    li
+      clear: left
+      
+      img
+        float: left
+        margin: 0 5px
+        width: 100px
+        height: 100px
+      p
+        margin-left: 110px


### PR DESCRIPTION
Addresses / fixes #84 and #85 
- Page routing & navigation added for "Tutorials" in Students and "Tutorials" Teachers.
- 2x Tutorial pages added, one for Students, one for Teachers. Fairly plain text, except for adding links to Zooniverse and WCG.

Query: Any preference between labelling these pages "Tutorial", "Help", "Guide", "How In Blazes Do I Do Anything?", "Information" or etc?

@simoneduca and @eatyourgreens , ready to review at any time.
