### PR TITLE
Updated Resources page and Site Header links

### DIFF
--- a/src/containers/Students.jsx
+++ b/src/containers/Students.jsx
@@ -30,6 +30,10 @@ Students.defaultProps = {
       to: '/students/tutorial'
     },
     {
+      label: 'Blog',
+      to: 'http://blog.wildcamgorongosa.org/'
+    },
+    {
       label: 'Feedback',
       to: 'https://docs.google.com/a/zooniverse.org/forms/d/1Cx4LDXevyqZZheB_EupVRxd7jCzpoH-m8j494cyNNfc/edit'
     }

--- a/src/containers/Teachers.jsx
+++ b/src/containers/Teachers.jsx
@@ -34,6 +34,10 @@ Teachers.defaultProps = {
       to: '/teachers/tutorial'
     },
     {
+      label: 'Blog',
+      to: 'http://blog.wildcamgorongosa.org/'
+    },
+    {
       label: 'Feedback',
       to: 'https://docs.google.com/a/zooniverse.org/forms/d/1Cx4LDXevyqZZheB_EupVRxd7jCzpoH-m8j494cyNNfc/edit'
     }

--- a/src/presentational/Resources.jsx
+++ b/src/presentational/Resources.jsx
@@ -12,21 +12,21 @@ const Resources = (props) => (
           <img src={require('../images/resources/1_ScientificInquiry_thumb.jpg')} />
           <h3>Scientific Inquiry Using WildCam Gorongosa</h3>
           <p>ACTIVITY</p>
-          <p>In this activity, students will be guided through the investigation of a scientific question, using data from trail cameras in Gorongosa National Park. View Activity></p>
+          <p>In this activity, students will be guided through the investigation of a scientific question, using data from trail cameras in Gorongosa National Park. <a href="http://www.hhmi.org/biointeractive/scientific-inquiry-using-wildcam-gorongosa" target="_blank">View Activity &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/2_BuildingEcologicalPyramids_thumb.jpg')} />
         <h3>Building Ecological Pyramids</h3>
         <p>ACTIVITY</p>
-        <p>In this activity, students will build biomass pyramids depicting trophic levels of various habitat types using data from trail cameras in Gorongosa National Park. View Activity></p>
+        <p>In this activity, students will build biomass pyramids depicting trophic levels of various habitat types using data from trail cameras in Gorongosa National Park. <a href="http://www.hhmi.org/biointeractive/building-ecological-pyramids" target="_blank">View Activity &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/3_MeasuringBiodiversity_thumb.jpg')} />
         <h3>Measuring Biodiversity in Gorongosa</h3>
         <p>ACTIVITY</p>
-        <p>In this activity, students will calculate species richness, evenness, and the Shannon diversity index for various habitat types using data from trail cameras in Gorongosa National Park. View Activity></p>
+        <p>In this activity, students will calculate species richness, evenness, and the Shannon diversity index for various habitat types using data from trail cameras in Gorongosa National Park. <a href="http://www.hhmi.org/biointeractive/measuring-biodiversity-gorongosa" target="_blank">View Activity &raquo;</a></p>
       </li>
     </ul>
 
@@ -36,68 +36,68 @@ const Resources = (props) => (
         <img src={require('../images/resources/4_TrackingLionRecovery_thumb.jpg')} />
         <h3>Tracking Lion Recovery in Gorongosa National Park</h3>
         <p>SCIENTIST AT WORK VIDEO</p>
-        <p>See how scientists in Gorongosa National Park are using GPS satellite collars and motion-sensitive cameras to gather data about the recovery of the park’s lion population. View Resource></p>
+        <p>See how scientists in Gorongosa National Park are using GPS satellite collars and motion-sensitive cameras to gather data about the recovery of the park’s lion population. <a href="http://www.hhmi.org/biointeractive/tracking-lion-recovery-gorongosa-national-park" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/5_iTunesUCourse_thumb.jpg')} />
         <h3>iTunes U Course: Using Citizen Science to Study Ecology</h3>
         <p>SHORT COURSE</p>
-        <p>This iTunes U course teaches concepts in ecology and scientific inquiry through a citizen science project in Gorongosa National Park, Mozambique. View Resource></p>
+        <p>This iTunes U course teaches concepts in ecology and scientific inquiry through a citizen science project in Gorongosa National Park, Mozambique. <a href="http://www.hhmi.org/biointeractive/itunes-u-course-gorongosa-using-citizen-science-study-ecology" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/6_GorongosaMap_thumb.jpg')} />
         <h3>Gorongosa National Park Interactive Map</h3>
         <p>INTERACTIVE</p>
-        <p>This interactive map of Gorongosa National Park allows users to explore different features of the park, including key components of the conservation strategy. View Resource></p>
+        <p>This interactive map of Gorongosa National Park allows users to explore different features of the park, including key components of the conservation strategy. <a href="http://www.hhmi.org/biointeractive/gorongosa-national-park-interactive-map" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/7_TheGuide_thumb.jpg')} />
         <h3>The Guide: A Biologist in Gorongosa</h3>
         <p>SHORT FILM</p>
-        <p>Set against the restoration of war-torn Gorongosa National Park in Mozambique, The Guide tells the story of a young man from the local community who discovers a passion for science after meeting world-renowned biologist E.O. Wilson. View Resource></p>
+        <p>Set against the restoration of war-torn Gorongosa National Park in Mozambique, The Guide tells the story of a young man from the local community who discovers a passion for science after meeting world-renowned biologist E.O. Wilson. <a href="http://www.hhmi.org/biointeractive/guide-biologist-gorongosa" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/8_GorongosaTimeline_thumb.jpg')} />
         <h3>Gorongosa Timeline </h3>           
         <p>INTERACTIVE</p>
-        <p>A highly visual interactive timeline for exploring the history of Gorongosa National Park, from its beginnings as a hunting reserve and decline in the wake of a civil war, to its return to being one of the world’s foremost wildlife treasures and case studies in conservation biology. View Resource></p>
+        <p>A highly visual interactive timeline for exploring the history of Gorongosa National Park, from its beginnings as a hunting reserve and decline in the wake of a civil war, to its return to being one of the world’s foremost wildlife treasures and case studies in conservation biology. <a href="http://www.hhmi.org/biointeractive/gorongosa-timeline" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/9_CreatingChainsWebs_thumb.jpg')} />   
         <h3>Creating Chains and Webs to Model Ecological Relationships</h3>    
         <p>ACTIVITY</p>
-        <p>Students use cards to build model food webs and evaluate how ecological disturbances affect each trophic level. View Resource></p>
+        <p>Students use cards to build model food webs and evaluate how ecological disturbances affect each trophic level. <a href="http://www.hhmi.org/biointeractive/creating-chains-and-webs-model-ecological-relationships" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/10_ExploringBiomes_thumb.jpg')} />
         <h3>Exploring Biomes in Gorongosa National Park</h3>    
         <p>ACTIVITY</p>
-        <p>Gorongosa National Park in Mozambique is a region with high ecological diversity that encompasses two distinct biomes. This activity introduces students to the concept of biomes in conjunction with the Gorongosa National Park interactive map click and learn. View Resource></p>
+        <p>Gorongosa National Park in Mozambique is a region with high ecological diversity that encompasses two distinct biomes. This activity introduces students to the concept of biomes in conjunction with the Gorongosa National Park interactive map click and learn. <a href="http://www.hhmi.org/biointeractive/exploring-biomes-gorongosa-national-park" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/11_SurveyingBiodiversity_thumb.jpg')} />
         <h3>Surveying Gorongosa’s Biodiversity</h3>    
         <p>SCIENTIST AT WORK VIDEO</p> 
-        <p>Biologists Piotr Naskrecki and Jennifer Guyton identify and record the diversity of species in Gorongosa National Park’s Cheringoma Plateau. View Resource></p>
+        <p>Biologists Piotr Naskrecki and Jennifer Guyton identify and record the diversity of species in Gorongosa National Park’s Cheringoma Plateau. <a href="http://www.hhmi.org/biointeractive/surveying-gorongosas-biodiversity" target="_blank">View Resource &raquo;</a></p>
       </li>
 
       <li>
         <img src={require('../images/resources/12_GorongosasWaterCycle_thumb.jpg')} />
         <h3>Gorongosa’s Water Cycle </h3>   
         <p>ANIMATION</p>
-        <p>This animation illustrates the main stages of the water cycle in the setting of Gorongosa National Park. View Resource></p>
+        <p>This animation illustrates the main stages of the water cycle in the setting of Gorongosa National Park. <a href="http://www.hhmi.org/biointeractive/gorongosas-water-cycle" target="_blank">View Resource &raquo;</a></p>
       </li>
     </ul>
 
 
-    <p>VIEW ALL RESOURCES> [Button links to Gorongosa collection]</p>
+    <p><a className="btn btn-default" href="http://www.biointeractive.org/gorongosa" target="_blank">Explore All Resources &raquo;</a></p>
   </div>
 );
 

--- a/src/styles/components/site-footer.styl
+++ b/src/styles/components/site-footer.styl
@@ -1,6 +1,6 @@
 .site-footer
   //The following isn't important; it's just a temporary styling for visuals ONLY and can be discarded for a proper footer.
-  background dark-grey url(../images/zooniverse.png) no-repeat center -50px
+  background dark-grey
   color #fff
   padding 1em
   text-align center

--- a/src/styles/components/site-header.styl
+++ b/src/styles/components/site-header.styl
@@ -3,8 +3,13 @@
   @extend .navbar-default
   @extend .navbar-static-top
   color #fff
-  background green url(../images/zooniverse.png) no-repeat center 5px
+  background green
   margin-bottom 0
+  
+  .navbar-brand
+    background url(../images/zooniverse.png) no-repeat center left
+    background-size 30px
+    padding-left 40px
 
   .title
     display inline-block


### PR DESCRIPTION
Resolves #83 and resolves #136 
- Links added to Teacher->Resources page, as per #136  
- "Blog" link added to Site Header (when in either Teacher or Student areas)
  - However, "FAQ" isn't added. See #83 for rationale.
- Zooniverse logo shifted into something smaller.

![screen shot 2016-03-29 at 18 08 31](https://cloud.githubusercontent.com/assets/13952701/14117011/8cdcb8bc-f5da-11e5-8e50-c26b01cc3c39.png)

Ready to roll, @simoneduca and @eatyourgreens :)
