### PR TITLE
Map Explorer - Improved SQL Queries & Results

### DIFF
--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -4,15 +4,15 @@
     "sqlApi": "https://shaunanoordin-zooniverse.cartodb.com/api/v2/sql?q={SQLQUERY}",
     "sqlTable": "wildcam_gorongosa_compiled_201601",
     "sqlTableCameras": "wildcam_gorongosa_cameras_201601",
-    "sqlTableSubjects": "wildcam_gorongosa_subjects_201601",
+    "sqlTableSubjects": "wildcam_gorongosa_subjects_201601_16000",
     "sqlTableClassifications": "wildcam_gorongosa_classifications_201601",
-    "sqlTableAggregations": "wildcam_gorongosa_aggregations_201603",
-    "sqlQueryCountCameras": "SELECT cameras.*, COUNT(items.*) as count FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.species, a.subject_id FROM {SUBJECTS} as a INNER JOIN {AGGREGATIONS} as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} GROUP BY cameras.cartodb_id",
+    "sqlTableAggregations": "wildcam_gorongosa_aggregations_201603a",
+    "sqlQueryCountCameras": "SELECT cameras.*, COUNT(items.*) as count FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.species, b.num_classifications, a.subject_id FROM {SUBJECTS} as a INNER JOIN {AGGREGATIONS} as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} GROUP BY cameras.cartodb_id",
     "sqlQueryCountCamerasCLASSIFICATIONSVER": "SELECT cameras.*, COUNT(items.*) as count FROM {CAMERAS} AS cameras LEFT JOIN (SELECT {SUBJECTS}.camera, {SUBJECTS}.location, {SUBJECTS}.dateutc, {SUBJECTS}.month, {SUBJECTS}.year, {SUBJECTS}.season, {SUBJECTS}.time_period, {CLASSIFICATIONS}.species, {CLASSIFICATIONS}.species_count, {CLASSIFICATIONS}.user_hash, {SUBJECTS}.subject_id, {CLASSIFICATIONS}.classification_id FROM {SUBJECTS} INNER JOIN {CLASSIFICATIONS} ON {SUBJECTS}.subject_id = {CLASSIFICATIONS}.subject_zooniverse_id) AS items ON cameras.id = items.camera {WHERE} GROUP BY cameras.cartodb_id",
     "sqlQueryViewCameraImagesOnly": "SELECT DISTINCT location FROM (SELECT cam.latitude, cam.longitude, cam.veg_type, cam.dist_humans_m, cam.human_type, cam.dist_water_m, cam.water_type, sbj.* FROM {CAMERAS} as cam INNER JOIN {SUBJECTS} as sbj ON cam.id = sbj.camera) as camsbj INNER JOIN {AGGREGATIONS} as agg ON camsbj.subject_id = agg.subject_id {WHERE}",
-    "sqlQueryViewCameraAll": "SELECT camsbj.*, agg.species FROM (SELECT cam.latitude, cam.longitude, cam.veg_type, cam.dist_humans_m, cam.human_type, cam.dist_water_m, cam.water_type, sbj.* FROM {CAMERAS} as cam INNER JOIN {SUBJECTS} as sbj ON cam.id = sbj.camera) as camsbj INNER JOIN {AGGREGATIONS} as agg ON camsbj.subject_id = agg.subject_id {WHERE}",
-    "sqlQuerySelectItems": "SELECT cameras.*, items.* FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.species, b.maximum_number_of_animals, b.minimum_number_of_animals, a.subject_id FROM {SUBJECTS} as a INNER JOIN {AGGREGATIONS} as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 1000",
-    "sqlQuerySelectItemsCLASSIFICATIONSVER": "SELECT cameras.*, items.* FROM {CAMERAS} AS cameras LEFT JOIN (SELECT {SUBJECTS}.camera, {SUBJECTS}.location, {SUBJECTS}.dateutc, {SUBJECTS}.month, {SUBJECTS}.year, {SUBJECTS}.season, {SUBJECTS}.time_period, {CLASSIFICATIONS}.species, {CLASSIFICATIONS}.species_count, {CLASSIFICATIONS}.user_hash, {SUBJECTS}.subject_id, {CLASSIFICATIONS}.classification_id FROM {SUBJECTS} INNER JOIN {CLASSIFICATIONS} ON {SUBJECTS}.subject_id = {CLASSIFICATIONS}.subject_zooniverse_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 1000",
+    "sqlQueryViewCameraAll": "SELECT camsbj.*, agg.species, agg.num_classifications FROM (SELECT cam.latitude, cam.longitude, cam.veg_type, cam.dist_humans_m, cam.human_type, cam.dist_water_m, cam.water_type, sbj.* FROM {CAMERAS} as cam INNER JOIN {SUBJECTS} as sbj ON cam.id = sbj.camera) as camsbj INNER JOIN {AGGREGATIONS} as agg ON camsbj.subject_id = agg.subject_id {WHERE}",
+    "sqlQuerySelectItems": "SELECT cameras.*, items.* FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.* FROM {SUBJECTS} as a INNER JOIN {AGGREGATIONS} as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 10000",
+    "sqlQuerySelectItemsCLASSIFICATIONSVER": "SELECT cameras.*, items.* FROM {CAMERAS} AS cameras LEFT JOIN (SELECT {SUBJECTS}.camera, {SUBJECTS}.location, {SUBJECTS}.dateutc, {SUBJECTS}.month, {SUBJECTS}.year, {SUBJECTS}.season, {SUBJECTS}.time_period, {CLASSIFICATIONS}.species, {CLASSIFICATIONS}.species_count, {CLASSIFICATIONS}.user_hash, {SUBJECTS}.subject_id, {CLASSIFICATIONS}.classification_id FROM {SUBJECTS} INNER JOIN {CLASSIFICATIONS} ON {SUBJECTS}.subject_id = {CLASSIFICATIONS}.subject_zooniverse_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 10000",
     "cssStandard": "#{LAYER} { marker-fill: {MARKERCOLOR}; marker-fill-opacity: {MARKEROPACITY}; marker-width: {MARKERSIZE}; marker-line-color: #FFF; marker-line-width: 1; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-allow-overlap: true; {CHILDREN} }"
   },
   "mapCentre": {
@@ -236,7 +236,7 @@
     {
       "id": "secbird",
       "dbName": "Secretary bird",
-      "displayName": "Secretary Bird"
+      "displayName": "Secretary Birds"
     },
     {
       "id": "serval",

--- a/src/containers/MapExplorer-SelectorData.jsx
+++ b/src/containers/MapExplorer-SelectorData.jsx
@@ -96,11 +96,16 @@ export default class SelectorData {
       ? '(camera ILIKE \''+specificCamera.replace(/'/, '\'\'').trim()+'\')'
       : '';
     
+    //SPECIAL CASE: Beta launch on 30 Mar 2016
+    //Currently, the Aggregated data is "unclean" and contains unexpected non-retired images.
+    //As a result, we're "cleaning" that data at runtime.
+    let sqlWhere_arbitraryMagicVoodoo = '(num_classifications >= 5)';
+    
     //Join the Where constructor
     let sqlWhere = '';
-    [sqlWhere_species, sqlWhere_habitats, sqlWhere_seasons, sqlWhere_dates, sqlWhere_user, sqlWhere_camera].map((wherePart) => {
+    [sqlWhere_species, sqlWhere_habitats, sqlWhere_seasons, sqlWhere_dates, sqlWhere_user, sqlWhere_camera, sqlWhere_arbitraryMagicVoodoo].map((wherePart) => {
       if (wherePart !== '') {
-        sqlWhere += (sqlWhere !== '') ? ' AND' : '';
+        sqlWhere += (sqlWhere !== '') ? ' AND ' : '';
         sqlWhere += wherePart;
       }
     });

--- a/src/presentational/DialogScreen-Download.jsx
+++ b/src/presentational/DialogScreen-Download.jsx
@@ -25,7 +25,7 @@ export default class DialogScreen_DownloadCSV extends DialogScreen {
           : null}
           
           {(this.props.data)
-          ? <div className="note">(Depending on your computer setup, you may need to right-click on the link above and choose "Save As", then open the downloaded file in Excel.)</div>
+          ? <div className="note">(Depending on your computer setup, you may need to right-click on the link above and choose "Save As", then open the downloaded file in Excel. At the moment, the download is limited to 10000 items per file.)</div>
           : null}
           
         </div>


### PR DESCRIPTION
- CartoDB now updated with improved Aggregations Data (thanks Greg!) and more Subjects data (16000 items instead of 10000 previously)
- Map Explorer now uses improved SQL queries to pull more relevant data for users to view. No more 'nonsense' results, like Elephants being labelled as Zebras - those stripes aren't that slimming, damn it.
  - Yes, there is a variable called `sqlWhere_arbitraryMagicVoodoo`, and it's called that _specifically_ because we need to revisit this issue and ask whether data should be cleaned at runtime, or pre-processed. (You have an idea what I prefer.)
- As a side effect to the change in SQL queries, the Download CSV feature now features _all the aggregation data_, which is something I'm sure Ali is super happy with. Hooray for data!

@simoneduca and @eatyourgreens , please let me know when you can review this; I plan this to be my last PR for the 'public test launch' tomorrow.
