### PR TITLE
Fix lack of PublicPath in Production's Webpack Config

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -18,6 +18,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist/'),
     filename: '[name]-[hash].min.js',
+    publicPath: '/',
   },
 
   plugins: [


### PR DESCRIPTION
Issue: If you go directly to https://learn.wildcamgorongosa.org/teachers/classrooms, the app won't load.
Analysis: This is caused by the app trying to load <script src="main-8874ee12d8d7858711ca.min.js"></script> instead of <script src="**/**main-8874ee12d8d7858711ca.min.js"></script>.
Solution: Add `publicPath` to `webpack.production.config.js`.
