### PR TITLE
Fixes Issue 153: Student Members are now counted uniquely

### DIFF
--- a/src/presentational/ClassroomsOverview.jsx
+++ b/src/presentational/ClassroomsOverview.jsx
@@ -38,7 +38,7 @@ const ClassroomsOverview = (props, context) => (
               </div>
               <div className="col-xs-9 text-right">
                 {(context.classrooms.loading === false) ?
-                <h1>{context.classrooms.members.length}</h1>
+                <h1>{context.classrooms.uniqueMemberLogins.length}</h1>
                 : <Spinner/>}
               </div>
             </div>

--- a/src/presentational/ClassroomsOverview.jsx
+++ b/src/presentational/ClassroomsOverview.jsx
@@ -38,7 +38,7 @@ const ClassroomsOverview = (props, context) => (
               </div>
               <div className="col-xs-9 text-right">
                 {(context.classrooms.loading === false) ?
-                <h1>{context.classrooms.uniqueMemberLogins.length}</h1>
+                <h1>{context.classrooms.uniqueMembers.length}</h1>
                 : <Spinner/>}
               </div>
             </div>

--- a/src/reducers/classrooms.js
+++ b/src/reducers/classrooms.js
@@ -1,6 +1,6 @@
 import * as types from '../constants/actionTypes';
 
-const initialState = { loading: false, data: [], error: false, members: [] };
+const initialState = { loading: false, data: [], error: false, members: [], uniqueMemberLogins: [] };
 
 
 export function classrooms(state = initialState, action) {
@@ -25,11 +25,18 @@ export function classrooms(state = initialState, action) {
         loading: true,
       });
     case types.RECEIVE_CLASSROOMS:
+      let uniqueMemberLogins = [];
+      action.members.map((item) => {
+        if (uniqueMemberLogins.indexOf(item.attributes.zooniverse_login) < 0) {
+          uniqueMemberLogins.push(item.attributes.zooniverse_login);
+        }
+      });
       return Object.assign({}, state, {
         loading: false,
         data: action.data || [],
         error: action.error,
         members: action.members || [],
+        uniqueMemberLogins: uniqueMemberLogins || [],
       });
     case types.RECEIVE_STUDENT_CLASSROOMS:
       return Object.assign({}, state, {

--- a/src/reducers/classrooms.js
+++ b/src/reducers/classrooms.js
@@ -1,6 +1,6 @@
 import * as types from '../constants/actionTypes';
 
-const initialState = { loading: false, data: [], error: false, members: [], uniqueMemberLogins: [] };
+const initialState = { loading: false, data: [], error: false, members: [], uniqueMembers: [] };
 
 
 export function classrooms(state = initialState, action) {
@@ -25,10 +25,10 @@ export function classrooms(state = initialState, action) {
         loading: true,
       });
     case types.RECEIVE_CLASSROOMS:
-      let uniqueMemberLogins = [];
+      let uniqueMembers = [];
       action.members.map((item) => {
-        if (uniqueMemberLogins.indexOf(item.attributes.zooniverse_login) < 0) {
-          uniqueMemberLogins.push(item.attributes.zooniverse_login);
+        if (uniqueMembers.indexOf(item.attributes.zooniverse_login) < 0) {
+          uniqueMembers.push(item.attributes.zooniverse_login);
         }
       });
       return Object.assign({}, state, {
@@ -36,7 +36,7 @@ export function classrooms(state = initialState, action) {
         data: action.data || [],
         error: action.error,
         members: action.members || [],
-        uniqueMemberLogins: uniqueMemberLogins || [],
+        uniqueMembers: uniqueMembers || [],
       });
     case types.RECEIVE_STUDENT_CLASSROOMS:
       return Object.assign({}, state, {


### PR DESCRIPTION
Fixes #153 
- Fixes the Student counter on the Teacher Overview page; the counter now only counts unique Zooniverse IDs/logins.
- The redux state now also keeps track of one new variable: `classrooms.uniqueMemberLogins`, which is a String array.

@simoneduca and @eatyourgreens, this is ready for review. Simone, if you want to suggest a better variable name than `uniqueMemberLogins`, do let me know - I realise my naming convention tends to be wordier than yours.
