### PR TITLE
Fix 144, 169, 170 - Login-secured Join Classrooms, Secure page fix, Navbar capitalisation compatibility

### DIFF
--- a/src/containers/Students.jsx
+++ b/src/containers/Students.jsx
@@ -1,13 +1,17 @@
 import { Component } from 'react';
 
-import Layout from '../presentational/Layout.jsx'
-
+import Layout from '../presentational/Layout.jsx';
 
 export default class Students extends Component {
 
   render() {
+    let loginSecured = this.props.navItems.reduce((prev, item, index, arr) => {  //Is this particular sub-page login secured?
+      console.log(prev, item.loginSecured, this.props.location.pathname.toLowerCase().startsWith(item.to), item.to);
+      return prev || (item.loginSecured === true && this.props.location.pathname.toLowerCase().startsWith(item.to));
+    }, false);
+    
     return (
-      <Layout {...this.props} navItems={this.props.navItems}>
+      <Layout {...this.props} loginSecured={loginSecured} navItems={this.props.navItems}>
         {this.props.children}
       </Layout>
     );
@@ -20,6 +24,7 @@ Students.defaultProps = {
     {
       label: 'Classrooms',
       to: '/students/classrooms',
+      loginSecured: true,
     },
     {
       label: 'Data',

--- a/src/containers/Students.jsx
+++ b/src/containers/Students.jsx
@@ -6,7 +6,6 @@ export default class Students extends Component {
 
   render() {
     let loginSecured = this.props.navItems.reduce((prev, item, index, arr) => {  //Is this particular sub-page login secured?
-      console.log(prev, item.loginSecured, this.props.location.pathname.toLowerCase().startsWith(item.to), item.to);
       return prev || (item.loginSecured === true && this.props.location.pathname.toLowerCase().startsWith(item.to));
     }, false);
     

--- a/src/presentational/Layout.jsx
+++ b/src/presentational/Layout.jsx
@@ -24,7 +24,7 @@ class Layout extends Component {
   }
 
   verifyLogin(props) {
-    if (this.props.loginInitialised && props.loginSecured && !(props.loginUser)) {
+    if (props.loginInitialised && props.loginSecured && !(props.loginUser)) {
       browserHistory.push(config.routes.loginPrompt);
     }
   }
@@ -49,7 +49,7 @@ class Layout extends Component {
         </li>
       );
     } else {  //Is it an internal link?
-      const isActive = (this.props.location.pathname ===  item.to) ? 'active' : null;
+      const isActive = (this.props.location.pathname.toLowerCase().startsWith(item.to)) ? 'active' : null;
       return (
         <li key={item.label} className={isActive}>
           <Link to={item.to}>{item.label}</Link>
@@ -71,7 +71,7 @@ class Layout extends Component {
         </header>
 
         <main className='content-section'>
-          {(!this.props.loginSecured || this.props.loginInitialised)
+          {(!this.props.loginSecured || (this.props.loginInitialised && this.props.loginUser))
           ? this.props.children
           : <div><Spinner/></div> }
         </main>


### PR DESCRIPTION
Fixes #144 - Join Classroom page is now login-secured
- **NOTE** we need to revisit the flow for this, because after a Student logs in, they won't be looking at the same "Join Classroom" page when they return from Panoptes. This has been an issue since the start, but this login prompt makes it that much more obvious.

Fixes #169 - Secure pages are now secure again
- If a non-logged user accesses a secured URL by typing in the URL directly, e.g. http://learn.wildcamgorongosa.org/teachers/data, they will now be properly prompted to log in.
- This was caused by a bug from #160 where `Layout.verifyLogin` was looking for `this.props.loginInitialised` instead of the correct `props.loginInitialised`, which mattered when `verifyLogin` was called by `componentWillReceiveProps`

Fixes #170 - NavBaR loVeS aLl CapitaliSAtioNS
- Navbar now recognises paths in all capitalisations, so /students/data/ works as fine as /STUDENTS/dAtA/

@eatyourgreens , this is ready for review.
