### PR TITLE
Allow access to specific classrooms by URL

### DIFF
--- a/src/containers/Classroom.jsx
+++ b/src/containers/Classroom.jsx
@@ -2,8 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { default as ClassroomPresentational } from '../presentational/Classroom.jsx';
-
-
+import Spinner from '../presentational/Spinner.jsx';
 
 export default class Classroom extends Component {
 
@@ -11,7 +10,11 @@ export default class Classroom extends Component {
     const members = this.props.classrooms.members;
     const classroom = this.props.classrooms.data.find(classroom =>
       classroom.id === this.props.params.classroomId);
-    return (<ClassroomPresentational data={classroom} members={members} />);
+    if (classroom && members) {
+      return (<ClassroomPresentational data={classroom} members={members} />);
+    } else {
+      return (<Spinner />);
+    }
   }
 
 }

--- a/src/containers/StudentClassroom.jsx
+++ b/src/containers/StudentClassroom.jsx
@@ -2,8 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { default as StudentClassroomPresentational } from '../presentational/StudentClassroom.jsx';
-
-
+import Spinner from '../presentational/Spinner.jsx';
 
 export default class StudentClassroom extends Component {
 
@@ -11,7 +10,12 @@ export default class StudentClassroom extends Component {
     const members = this.props.classrooms.members;
     const classroom = this.props.classrooms.data.find(classroom =>
       classroom.id === this.props.params.classroomId);
-    return (<StudentClassroomPresentational data={classroom} members={members} user={this.props.user} />);
+    
+    if (classroom && members) {
+      return (<StudentClassroomPresentational data={classroom} members={members} user={this.props.user} />);
+    } else {
+      return (<Spinner />);
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #181 
Requires #180  
- (Logged in) users can now access specific Teacher and Student classrooms by typing the URL. e.g. https://learn.wildcamgorongosa.org/teachers/classrooms/38
- This also fixes the bug where the app crashes when you reload the page when viewing a specific Teacher/Student classroom.
- Quite simply, for the 'view specific classroom' components (`containers/Classroom.jsx` and `containers/StudentClassroom.jsx`) we simply added a check to see if the classroom data has loaded or not. If no, we present the 'loading spinner' while the data loads. (Previously, the app would just crash, expecting fully loaded data.)

This PR is ready for review, but PLEASE DO NOT MERGE IT YET. This PR is based off PR #180 (i.e. branch `fix-179`), so that needs to be merged first . Once that's done, please let me know and I'll rebase `fix-181` onto the new `master`.

(Alternatively, I can imagine merging this `fix-181` branch into the `fix-179` branch, then merging that into `master`, but that requires more Git voodoo than I'm comfortable with.)
