### PR TITLE
Allow access to specific classrooms by URL

### DIFF
--- a/src/containers/Classroom.jsx
+++ b/src/containers/Classroom.jsx
@@ -2,8 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { default as ClassroomPresentational } from '../presentational/Classroom.jsx';
-
-
+import Spinner from '../presentational/Spinner.jsx';
 
 export default class Classroom extends Component {
 
@@ -11,7 +10,11 @@ export default class Classroom extends Component {
     const members = this.props.classrooms.members;
     const classroom = this.props.classrooms.data.find(classroom =>
       classroom.id === this.props.params.classroomId);
-    return (<ClassroomPresentational data={classroom} members={members} />);
+    if (classroom && members) {
+      return (<ClassroomPresentational data={classroom} members={members} />);
+    } else {
+      return (<Spinner />);
+    }
   }
 
 }

--- a/src/containers/StudentClassroom.jsx
+++ b/src/containers/StudentClassroom.jsx
@@ -2,8 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { default as StudentClassroomPresentational } from '../presentational/StudentClassroom.jsx';
-
-
+import Spinner from '../presentational/Spinner.jsx';
 
 export default class StudentClassroom extends Component {
 
@@ -11,7 +10,12 @@ export default class StudentClassroom extends Component {
     const members = this.props.classrooms.members;
     const classroom = this.props.classrooms.data.find(classroom =>
       classroom.id === this.props.params.classroomId);
-    return (<StudentClassroomPresentational data={classroom} members={members} user={this.props.user} />);
+    
+    if (classroom && members) {
+      return (<StudentClassroomPresentational data={classroom} members={members} user={this.props.user} />);
+    } else {
+      return (<Spinner />);
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #181 
Suprecedes #182
- (Logged in) users can now access specific Teacher and Student classrooms by typing the URL. e.g. https://learn.wildcamgorongosa.org/teachers/classrooms/38
- This also fixes the bug where the app crashes when you reload the page when viewing a specific Teacher/Student classroom.
- Quite simply, for the 'view specific classroom' components (containers/Classroom.jsx and containers/StudentClassroom.jsx) we simply added a check to see if the classroom data has loaded or not. If no, we present the 'loading spinner' while the data loads. (Previously, the app would just crash, expecting fully loaded data.)
