### PR TITLE
Users with no previously-created classrooms can now properly access Teacher classrooms

### DIFF
--- a/src/reducers/teacher.js
+++ b/src/reducers/teacher.js
@@ -24,7 +24,7 @@ export function teacher(state = initialState, action) {
       });
     case types.RECEIVE_CLASSROOMS:
       let uniqueMembers = [];
-      action.members.map((item) => {
+      action.members && action.members.map((item) => {
         if (uniqueMembers.indexOf(item.attributes.zooniverse_login) < 0) {
           uniqueMembers.push(item.attributes.zooniverse_login);
         }


### PR DESCRIPTION
Fixes #185 
- The RECEIVE_CLASSROOMS Redux reducer now checks if the input has the necessary data values before using them.
- This bug was introduced when the `uniqueMembers` for Teacher classrooms was built in; the code incorrectly assumed that the JSON response from the Education API would _always_ have `json.included`. (i.e. a list of members of all the classrooms you've created.) In reality, the Education API wouldn't include a `.included` value if, say, you had no classrooms to even have members to begin with.

Ready for review!
