### PR TITLE
Add Classrooms and Classifications counters to Student Overview

### DIFF
--- a/src/containers/StudentClassrooms.jsx
+++ b/src/containers/StudentClassrooms.jsx
@@ -8,24 +8,27 @@ import StudentClassroomsSidebar from '../presentational/StudentClassroomsSidebar
 class StudentClassrooms extends Component {
 
   componentDidMount() {
-    if (!this.props.classrooms.members.length && !this.props.classrooms.data.length && !this.props.classrooms.loading) {
-      this.props.dispatch(fetchStudentClassrooms());
+    const {classrooms, dispatch} = this.props;
+    if (!classrooms.members.length && !classrooms.data.length && !classrooms.loading) {
+      dispatch(fetchStudentClassrooms());
     }
   }
-  
+
   getChildContext() {
+    const {classrooms, user} = this.props;
     return {
-      classrooms: this.props.classrooms,
-      user: this.props.user
+      classrooms: classrooms,
+      user: user
     }
   }
 
   render() {
+    const {children, classrooms} = this.props;
     return (
       <div className="admin-component">
         <div className="row">
-          <StudentClassroomsSidebar classroomsData={this.props.classrooms} />
-          {this.props.children}
+          <StudentClassroomsSidebar classroomsData={classrooms} />
+          {children}
         </div>
       </div>
     );

--- a/src/containers/StudentClassrooms.jsx
+++ b/src/containers/StudentClassrooms.jsx
@@ -12,6 +12,13 @@ class StudentClassrooms extends Component {
       this.props.dispatch(fetchStudentClassrooms());
     }
   }
+  
+  getChildContext() {
+    return {
+      classrooms: this.props.classrooms,
+      user: this.props.user
+    }
+  }
 
   render() {
     return (
@@ -28,6 +35,7 @@ class StudentClassrooms extends Component {
 
 StudentClassrooms.propTypes = {
   classrooms: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
 };
 
@@ -37,7 +45,12 @@ StudentClassrooms.defaultProps = {
     error: false,
     loading: false,
     members: [],
-  }
+  },
+  user: null
+};
+StudentClassrooms.childContextTypes = {
+  classrooms: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired
 };
 
 function mapStateToProps(state) {

--- a/src/presentational/StudentOverview.jsx
+++ b/src/presentational/StudentOverview.jsx
@@ -1,20 +1,73 @@
-import { Component, PropTypes } from 'react';
-import { Link } from 'react-router';
-import JoinClassroom from '../containers/JoinClassroom.jsx';
+import { PropTypes } from 'react';
+import Spinner from 'Spinner.jsx'
 
-
-export default class StudentOverview extends Component {
-
-  // TODO: if logged in show basic student details
-  // else show Join Classroom
-
-  render() {
-    return (
-      <div>
-        <h3>Student Overview</h3>
-        Start classifying at <a href="https://wildcamgorongosa.org" target="_blank">wildcamgorongosa.org</a>
-      </div>
-    );
+const StudentOverview = (props, context) => {
+  
+  let myClassifications = false;  
+  if (context.classrooms && context.classrooms.members && context.classrooms.loading === false && context.user) {
+    myClassifications = context.classrooms.members.reduce((prev, cur, index, arr) => {
+      return prev + ((context.user.id === cur.attributes.zooniverse_id) ? cur.attributes.classifications_count : 0);
+    }, 0);
   }
+  
+  return (
+    <section className="content-view">
+      <div className="row">
+        <div className="page-header">
+          <h1>Student Overview</h1>
+        </div>
+      </div>
+      <div className="panel panel-info">
+        <div className="panel-body">
+          Start classifying at <a href="https://wildcamgorongosa.org" target="_blank">wildcamgorongosa.org</a>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-lg-3 col-md-6">
+          <div className="panel panel-info">
+            <div className="panel-heading">
+              <div className="panel-title row">
+                <div className="col-xs-3">
+                  <i className="fa fa-institution fa-4x"></i>
+                </div>
+                <div className="col-xs-9 text-right">
+                  {(context.classrooms.loading === false) ?
+                  <h1>{context.classrooms.data.length}</h1>
+                  : <Spinner/>}
+                </div>
+              </div>
+            </div>
+            <div className="panel-footer text-right">
+              <div>Classrooms</div>
+            </div>
+          </div>
+        </div>
+        <div className="col-lg-3 col-md-6">
+          <div className="panel panel-info">
+            <div className="panel-heading">
+              <div className="panel-title row">
+                <div className="col-xs-3">
+                  <i className="fa fa-pencil-square-o fa-4x"></i>
+                </div>
+                <div className="col-xs-9 text-right">
+                  {(myClassifications !== false) ?
+                  <h1>{myClassifications}</h1>
+                  : <Spinner/>}
+                </div>
+              </div>
+            </div>
+            <div className="panel-footer text-right">
+              <div>Classifications</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+)};
 
+StudentOverview.contextTypes = {
+  classrooms: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired
 }
+
+export {StudentOverview as default}

--- a/src/presentational/StudentOverview.jsx
+++ b/src/presentational/StudentOverview.jsx
@@ -2,14 +2,15 @@ import { PropTypes } from 'react';
 import Spinner from 'Spinner.jsx'
 
 const StudentOverview = (props, context) => {
-  
-  let myClassifications = false;  
-  if (context.classrooms && context.classrooms.members && context.classrooms.loading === false && context.user) {
-    myClassifications = context.classrooms.members.reduce((prev, cur, index, arr) => {
-      return prev + ((context.user.id === cur.attributes.zooniverse_id) ? cur.attributes.classifications_count : 0);
+
+  let myClassifications = false;
+  const {classrooms, user} = context;
+  if (classrooms && classrooms.members && classrooms.loading === false && user) {
+    myClassifications = classrooms.members.reduce((prev, cur, index, arr) => {
+      return prev + ((user.id === cur.attributes.zooniverse_id) ? cur.attributes.classifications_count : 0);
     }, 0);
   }
-  
+
   return (
     <section className="content-view">
       <div className="row">
@@ -31,8 +32,8 @@ const StudentOverview = (props, context) => {
                   <i className="fa fa-institution fa-4x"></i>
                 </div>
                 <div className="col-xs-9 text-right">
-                  {(context.classrooms.loading === false) ?
-                  <h1>{context.classrooms.data.length}</h1>
+                  {(classrooms.loading === false) ?
+                  <h1>{classrooms.data.length}</h1>
                   : <Spinner/>}
                 </div>
               </div>


### PR DESCRIPTION
Closes #168 

<img width="1280" alt="screen shot 2016-04-27 at 23 55 19" src="https://cloud.githubusercontent.com/assets/13952701/14870654/9dda02e0-0cd3-11e6-83da-5c957a54c957.png">
- Accessing the Students Overview (`~/students/classrooms`) now shows the number of Classrooms you've joined and the number of Classifications you've made as part of the classroom.
- The number of Classifications, at this moment, will always show 0, as the Education API is being actively updated to support this feature. I think that's tied to... #177?

Anyway, ready for review!
