### PR TITLE
Add scrollbar to sidebar.

### DIFF
--- a/src/presentational/ClassroomsOverview.jsx
+++ b/src/presentational/ClassroomsOverview.jsx
@@ -4,10 +4,8 @@ import Spinner from 'Spinner.jsx'
 
 const ClassroomsOverview = (props, context) => (
   <section className="content-view">
-    <div className="row">
-      <div className="page-header">
-        <h1>Overview</h1>
-      </div>
+    <div className="page-header">
+      <h1>Overview</h1>
     </div>
     <div className="row">
       <div className="col-lg-3 col-md-6">

--- a/src/styles/components/admin-sidebar.styl
+++ b/src/styles/components/admin-sidebar.styl
@@ -1,4 +1,8 @@
 .admin-sidebar
   @extend .col-sm-3
+  background-color off-white
+  max-height 500px
+  overflow-y auto
   padding-left 0
+  padding-right 0
 


### PR DESCRIPTION
Saves users from scrolling up and down the screen in order to see a classroom details, when there are many classrooms in the sidebar.
