### PR TITLE
Component.PropTypes renamed to Component.propTypes

### DIFF
--- a/src/presentational/CheckboxGroup.jsx
+++ b/src/presentational/CheckboxGroup.jsx
@@ -53,6 +53,6 @@ CheckboxGroup.defaultProps = {
   value: null,
 }
 
-CheckboxGroup.PropTypes = {
+CheckboxGroup.propTypes = {
   options: PropTypes.array.isRequired
 }

--- a/src/presentational/ClassroomsSidebar.jsx
+++ b/src/presentational/ClassroomsSidebar.jsx
@@ -73,7 +73,7 @@ export default class ClassroomSidebar extends Component {
 
 }
 
-ClassroomSidebar.PropTypes = {
+ClassroomSidebar.propTypes = {
   classroomsData: PropTypes.object.isRequired,
   userdetails: PropTypes.object.isRequired,
 };
@@ -88,6 +88,3 @@ ClassroomSidebar.defaultProps = {
     loading: false,
   }
 };
-
-
-

--- a/src/presentational/Dropdown.jsx
+++ b/src/presentational/Dropdown.jsx
@@ -44,6 +44,6 @@ Dropdown.defaultProps = {
   value: null,
 }
 
-Dropdown.PropTypes = {
+Dropdown.propTypes = {
   options: PropTypes.array.isRequired
 }

--- a/src/presentational/RadioButtonGroup.jsx
+++ b/src/presentational/RadioButtonGroup.jsx
@@ -43,6 +43,6 @@ RadioButtonGroup.defaultProps = {
   value: null,
 }
 
-RadioButtonGroup.PropTypes = {
+RadioButtonGroup.propTypes = {
   options: PropTypes.array.isRequired
 }

--- a/src/presentational/StudentClassroomsSidebar.jsx
+++ b/src/presentational/StudentClassroomsSidebar.jsx
@@ -64,6 +64,6 @@ export default class StudentClassroomSidebar extends Component {
 
 }
 
-StudentClassroomSidebar.PropTypes = {
+StudentClassroomSidebar.propTypes = {
   classroomsData: PropTypes.object.isRequired,
 };

--- a/src/presentational/TeacherForm.jsx
+++ b/src/presentational/TeacherForm.jsx
@@ -163,7 +163,7 @@ class TeacherForm extends Component {
   }
 }
 
-TeacherForm.PropTypes = {
+TeacherForm.propTypes = {
   dispatch: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
> Slack 27 Apr 2016 # wildcam-education
> Roger Hutchings 5:03 PM @ channel - working on some code for this atm. i’m seeing a lot of ComponentName.PropTypes - it should be ComponentName.propTypes (note case) otherwise it does nothing

As @rogerhutchings pointed out, some components were using the incorrect capitalisation for the `.propTypes` property; this PR fixes that.
