### PR TITLE
Student Classrooms Overview only count unique Classifications

### DIFF
--- a/src/presentational/StudentOverview.jsx
+++ b/src/presentational/StudentOverview.jsx
@@ -3,12 +3,19 @@ import Spinner from 'Spinner.jsx'
 
 const StudentOverview = (props, context) => {
 
-  let myClassifications = false;
   const {classrooms, user} = context;
+  
+  let myClassifications = false;
   if (classrooms && classrooms.members && classrooms.loading === false && user) {
-    myClassifications = classrooms.members.reduce((prev, cur, index, arr) => {
-      return prev + ((user.id === cur.attributes.zooniverse_id) ? cur.attributes.classifications_count : 0);
-    }, 0);
+    myClassifications = 0;
+    classrooms.members.map((student) => {
+      if (user.id === student.attributes.zooniverse_id)
+        myClassifications = Math.max(student.attributes.classifications_count, myClassifications);
+    });
+    //NOTE: The current Classifications counter assumes that each Classroom the
+    //Student is in shares the same number of *unique* classifications.
+    //Previously, this was an array.reduce() function that totalled the number
+    //of Classifications across all Classrooms the Student is in.
   }
 
   return (


### PR DESCRIPTION
- What the title says

So here's the weird thing: what kind of numbers do we want to show on the Student Overview? What counts as my "total number of Classifications"?

Say I've joined 3 classes, then at WildCam Gorongosa, I make 5 separate Classifications. Technically I've only made 5 unique Classifications... but I did it (simultaneously) for 3 different classes. Does that mean I've made 15 total Classifications??

(Remember, at the moment, every class is for the same WildCam Gorongosa project, not different projects, where summing the Classifications across classes would make a wee bit more sense.)

This PR changes the behaviour of the Overview to ignores 'multiple' Classifications across every classroom and only counts unique Classifications - i.e. go through all the Classrooms the Student is a part of then pluck the biggest number. That sounds about right.

Ready for review.
