### PR TITLE
Fix references to features in Panoptes-Client (?)

### DIFF
--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -32,7 +32,7 @@ import Styles from './styles/main.styl';
 import configureStore from './store';
 const store = configureStore();
 
-import { oauth } from 'panoptes-client';
+import oauth from 'panoptes-client/lib/oauth';
 import config from './constants/config';
 
 window.React = React;

--- a/src/actions/login.js
+++ b/src/actions/login.js
@@ -1,12 +1,13 @@
 import * as types from '../constants/actionTypes';
-import Panoptes from 'panoptes-client';
+import auth from 'panoptes-client/lib/auth';
+import oauth from 'panoptes-client/lib/oauth';
 import config from '../constants/config';
 
 //Action creators
 
 export function checkLoginUser() {  //First thing on app load - check if the user is logged in.
   return (dispatch) => {
-    Panoptes.auth.checkCurrent()
+    auth.checkCurrent()
       .then((user) => {
         dispatch(setLoginUser(user));
       });
@@ -24,13 +25,13 @@ export function setLoginUser(user) {
 
 export function loginToPanoptes() {  //Returns a login page URL for the user to navigate to.
   return (dispatch) => {
-    return Panoptes.oauth.signIn(config.panoptesReturnUrl)
+    return oauth.signIn(config.panoptesReturnUrl)
   }
 }
 
 export function logoutFromPanoptes() {
   return (dispatch) => {
-    Panoptes.oauth.signOut()
+    oauth.signOut()
       .then(user => {
         dispatch(setLoginUser(user));
       });

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -1,5 +1,4 @@
 import * as types from '../constants/actionTypes';
-import Panoptes from 'panoptes-client';
 import config from '../constants/config';
 
 //Action creators

--- a/src/actions/student.js
+++ b/src/actions/student.js
@@ -1,6 +1,6 @@
 import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
-import Panoptes from 'panoptes-client';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import config from '../constants/config';
 import * as types from '../constants/actionTypes';
@@ -17,7 +17,7 @@ export function joinClassroom(id, token) {
       method: 'POST',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
       }),
       body: JSON.stringify({'join_token': token})
@@ -43,7 +43,7 @@ export function fetchStudentClassrooms() {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
         })
       })

--- a/src/actions/teacher.js
+++ b/src/actions/teacher.js
@@ -1,6 +1,6 @@
 import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
-import Panoptes from 'panoptes-client';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import config from '../constants/config';
 import * as types from '../constants/actionTypes';
@@ -21,7 +21,7 @@ export function createClassroom(name, subject, school, description) {
       method: 'POST',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
       }),
       body: JSON.stringify({
@@ -57,7 +57,7 @@ export function fetchClassrooms() {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
         })
       })

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1,6 +1,6 @@
 import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
-import Panoptes from 'panoptes-client';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import config from '../constants/config';
 import * as types from '../constants/actionTypes';
@@ -14,7 +14,7 @@ export function fetchUserDetails(userId) {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({
-        'Authorization': Panoptes.apiClient.headers.Authorization,
+        'Authorization': apiClient.headers.Authorization,
         'Content-Type': 'application/json'
       })
     })
@@ -37,7 +37,7 @@ export function upsertTeacherMetadata(userId, data) {
       method: 'PUT',
       mode: 'cors',
       headers: new Headers({
-        'Authorization': Panoptes.apiClient.headers.Authorization,
+        'Authorization': apiClient.headers.Authorization,
         'Content-Type': 'application/json'
       }),
       body: JSON.stringify({


### PR DESCRIPTION
Issue: After deleting `node_modules` and reinstalling, the app would no longer run on localhost. Error message was _"Uncaught TypeError: Cannot read property 'init' of undefined"_ in `Index.jsx`

Analysis:
- Trigger was `oath.init()` in Index.jsx
- Features from the Panoptes Client are no longer recognised - e.g. `import { oauth } from 'panoptes-client';` in `Index.jsx` would be `undefined`
- Strangely, checking the Panoptes-Client repo showed that feature imports should be done like this...

```
import apiClient from 'panoptes-client/lib/api-client'
import auth from 'panoptes-client/lib/auth'
import oauth from 'panoptes-client/lib/oauth'
import talkClient from 'panoptes-client/lib/talk-client'
```

...instead of...

```
import { oauth } from 'panoptes-client';
//or
import Panoptes from 'panoptes-client';
Panoptes.apiClient.whatever()
```

...which is how it's currently being used.
- Unsure if everything was "working OK until now" because the panoptes-client on my localhost was using an older version of the Panoptes-Client where `import { oauth } from 'panoptes-client';` still worked.

Solution(?):
- Changed Panoptes feature references (mostly in `Index.jsx` and in `/actions`) to the format above.
- Then, before continuing development, **delete `/node_modules`** and reinstall with `npm install` to start afresh. Nuke the entire folder from orbit - it's the only way to be sure.

@simoneduca and @eatyourgreens, I'd like to discuss if either of you are encountering these kinds of problems - e.g. with a fresh clone. 
