### PR TITLE
Fix references to features in Panoptes-Client (edit-form Branch) 

### DIFF
--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -34,7 +34,7 @@ import Styles from './styles/main.styl';
 import configureStore from './store';
 const store = configureStore();
 
-import { oauth } from 'panoptes-client';
+import oauth from 'panoptes-client/lib/oauth';
 import config from './constants/config';
 
 window.React = React;

--- a/src/actions/login.js
+++ b/src/actions/login.js
@@ -1,12 +1,13 @@
 import * as types from '../constants/actionTypes';
-import Panoptes from 'panoptes-client';
+import auth from 'panoptes-client/lib/auth';
+import oauth from 'panoptes-client/lib/oauth';
 import config from '../constants/config';
 
 //Action creators
 
 export function checkLoginUser() {  //First thing on app load - check if the user is logged in.
   return (dispatch) => {
-    Panoptes.auth.checkCurrent()
+    auth.checkCurrent()
       .then(user => {
         dispatch(setLoginUser(user));
       });
@@ -24,13 +25,13 @@ export function setLoginUser(user) {
 
 export function loginToPanoptes() {  //Returns a login page URL for the user to navigate to.
   return (dispatch) => {
-    return Panoptes.oauth.signIn(config.panoptesReturnUrl)
+    return oauth.signIn(config.panoptesReturnUrl)
   }
 }
 
 export function logoutFromPanoptes() {
   return (dispatch) => {
-    Panoptes.oauth.signOut()
+    oauth.signOut()
       .then(user => {
         dispatch(setLoginUser(user));
       });

--- a/src/actions/student.js
+++ b/src/actions/student.js
@@ -1,6 +1,6 @@
 import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
-import Panoptes from 'panoptes-client';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import config from '../constants/config';
 import * as types from '../constants/actionTypes';
@@ -17,7 +17,7 @@ export function joinClassroom(id, token) {
       method: 'POST',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
       }),
       body: JSON.stringify({'join_token': token})
@@ -43,7 +43,7 @@ export function fetchStudentClassrooms() {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
         })
       })

--- a/src/actions/teacher.js
+++ b/src/actions/teacher.js
@@ -1,6 +1,6 @@
 import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
-import Panoptes from 'panoptes-client';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import config from '../constants/config';
 import * as types from '../constants/actionTypes';
@@ -17,7 +17,7 @@ export function createClassroom(classroom) {
       method: 'POST',
       mode: 'cors',
       headers: new Headers({
-        'Authorization': Panoptes.apiClient.headers.Authorization,
+        'Authorization': apiClient.headers.Authorization,
         'Content-Type': 'application/json'
       }),
       body: JSON.stringify({
@@ -47,7 +47,7 @@ export function editClassroom(fields, classroomId) {
       method: 'PUT',
       mode: 'cors',
       headers: new Headers({
-        'Authorization': Panoptes.apiClient.headers.Authorization,
+        'Authorization': apiClient.headers.Authorization,
         'Content-Type': 'application/json'
       }),
       body: JSON.stringify({
@@ -75,7 +75,7 @@ export function fetchClassrooms() {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({
-          'Authorization': Panoptes.apiClient.headers.Authorization,
+          'Authorization': apiClient.headers.Authorization,
           'Content-Type': 'application/json'
         })
       })

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1,6 +1,6 @@
 import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
-import Panoptes from 'panoptes-client';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import config from '../constants/config';
 import * as types from '../constants/actionTypes';
@@ -14,7 +14,7 @@ export function fetchUserDetails(userId) {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({
-        'Authorization': Panoptes.apiClient.headers.Authorization,
+        'Authorization': apiClient.headers.Authorization,
         'Content-Type': 'application/json'
       })
     })
@@ -37,7 +37,7 @@ export function upsertTeacherMetadata(userId, data) {
       method: 'PUT',
       mode: 'cors',
       headers: new Headers({
-        'Authorization': Panoptes.apiClient.headers.Authorization,
+        'Authorization': apiClient.headers.Authorization,
         'Content-Type': 'application/json'
       }),
       body: JSON.stringify({

--- a/src/presentational/Home.jsx
+++ b/src/presentational/Home.jsx
@@ -1,6 +1,5 @@
 import { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
-import Panoptes from 'panoptes-client';
 
 import Layout from './Layout.jsx'
 


### PR DESCRIPTION
Supercedes #210 

Issue: After deleting `node_modules` and reinstalling, the app would no longer run on localhost. Error message was _"Uncaught TypeError: Cannot read property 'init' of undefined"_ in `Index.jsx`

Analysis: Features from the Panoptes Client are no longer recognised - e.g. `import { oauth } from 'panoptes-client';` in `Index.jsx` would be `undefined`

Solution: Fixed references to reflect latest Panoptes Client usage requirements, e.g. from `import { oauth } from 'panoptes-client';` to `import oauth from 'panoptes-client/lib/oauth'`

This is being merged into `edit-form` instead of `master` because the fixes are required on #188 first for it to be tested. See #188 for a [bit more info](https://github.com/zooniverse/wildcam-gorongosa-education/pull/188#issuecomment-220574431)

@simoneduca, this is ready for review; I' also continuing to test the #188 branch based on these updates.
