### PR TITLE
Teacher's Classroom List now reflects most recent Edited Classroom

### DIFF
--- a/src/actions/teacher.js
+++ b/src/actions/teacher.js
@@ -59,6 +59,8 @@ export function editClassroom(fields, classroomId) {
     .then(response => {
       dispatch({
         type: types.EDIT_CLASSROOM_SUCCESS,
+        fields: fields,
+        classroomId: classroomId,
       });
       browserHistory.push(`/teachers/classrooms/${classroomId}`);
     } )

--- a/src/presentational/EditClassroomLink.jsx
+++ b/src/presentational/EditClassroomLink.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 const EditClassroomLink = ({ classroom }) => {
   const linkUrl = `/teachers/classrooms/${classroom.id}/edit`;
   return (
-    <Link to={linkUrl}>
+    <Link className="btn btn-warning" to={linkUrl}>
       Edit classroom
     </Link>
   );

--- a/src/presentational/NewClassroomForm.jsx
+++ b/src/presentational/NewClassroomForm.jsx
@@ -60,21 +60,21 @@ class NewClassroomForm extends Component {
 
         <NewClassroomFormElement
           label="Subject"
-          placeholder="Subject (Optional)"
+          placeholder="Subject"
           value={this.state.subject}
           onChange={this.handleChange}
         />
 
         <NewClassroomFormElement
           label="School"
-          placeholder="School (Optional)"
+          placeholder="School"
           value={this.state.school}
           onChange={this.handleChange}
         />
 
         <NewClassroomFormElement
           label="Description"
-          placeholder="Description (Optional)"
+          placeholder="Description"
           value={this.state.description}
           onChange={this.handleChange}
         />

--- a/src/presentational/NewClassroomFormElement.jsx
+++ b/src/presentational/NewClassroomFormElement.jsx
@@ -11,6 +11,7 @@ const NewClassroomFormElement = props => {
       <span>{ label }</span>
       <input className="form-control"
         type="text"
+        required
         { ...other }
       />
     </label>

--- a/src/reducers/teacher.js
+++ b/src/reducers/teacher.js
@@ -23,10 +23,19 @@ export function teacher(state = initialState, action) {
         }
       }
     case types.EDIT_CLASSROOM_SUCCESS:
+      const newData = state.classrooms.data.map(classroom => {
+        if (classroom.id === action.classroomId) {
+          return Object.assign({}, classroom,
+            { attributes: Object.assign({}, classroom.attributes, {}, action.fields) }
+          );
+        }
+        return classroom;
+      });
+  
       return { ...state,
         classrooms: {
           loading: false,
-          data: state.classrooms.data,
+          data: newData,
           error: false,
           members: state.classrooms.members || [],
           uniqueMembers: state.classrooms.uniqueMembers,


### PR DESCRIPTION
Addresses an issue brought up in #188 

Issue 1: After using Edit Classroom and clicking Submit, the list of Classrooms does not update to reflect the changes.
Analysis:
- Refreshing the page, however, shows that the Classroom List is properly updated.
- This indicates that the API was called correctly, but the return doesn't properly update the current `state.teachers` data

Solution: `EDIT_CLASSROOM_SUCCESS` action & reducers tweaked so that when the event triggers, the state's list of classroom is updated with the most recently (successful) edits.

@simoneduca , this is good to go. This PR can be reviewed & merged separately from #211 (i.e. 211 is _not_ a requirement for this to be merged into `edit-form`) 
