### PR TITLE
IE10 + Edge Fixes: View Camera popup correctly size & popup dialogs close properly

### DIFF
--- a/src/presentational/DialogScreen-Download.jsx
+++ b/src/presentational/DialogScreen-Download.jsx
@@ -5,6 +5,7 @@ import {saveAs} from 'browser-filesaver';
 export default class DialogScreen_DownloadCSV extends DialogScreen {
   constructor(props) {
     super(props);
+    this.closeMe = this.closeMe.bind(this);  //Babel doesn't transpile super() properly in IE10, so we need to explicitly declare this.
     this.downloadCsv = this.downloadCsv.bind(this);
     this.blobbifyCsvData = this.blobbifyCsvData.bind(this);
     this.generateFilename = this.generateFilename.bind(this);

--- a/src/presentational/DialogScreen-ViewCamera.jsx
+++ b/src/presentational/DialogScreen-ViewCamera.jsx
@@ -4,6 +4,7 @@ import DialogScreen from './DialogScreen.jsx';
 export default class DialogScreen_ViewCamera extends DialogScreen {
   constructor(props) {
     super(props);
+    this.closeMe = this.closeMe.bind(this);  //Babel doesn't transpile super() properly in IE10, so we need to explicitly declare this.
   }
 
   render() {

--- a/src/styles/components/dialog-screen.styl
+++ b/src/styles/components/dialog-screen.styl
@@ -46,6 +46,7 @@
       list-style: none
       padding: 0
       margin: 0.5em 0 0 0
+      width: 80vw
       max-width: 1000px;
       
       li


### PR DESCRIPTION
Fixes #196
Fixes issue reported by @eatyourgreens on Slack:

> "Hmmm, if I open the camera popup on the map in IE10, I can’t close it again (or click on the map behind the overlay)"

Issue 1: The View Camera popup looks absolutely tiny in Edge and IE10
Analysis: In Edge/IE10, the container element (dialog-box ul) does not expand to fit its content (images)
Solution: Set a specific width for the container element

Issue 2: Attempting to close a View Camera or Download CSV popup dialog causes the app to crash

Analysis:
- The `DialogScreen-ViewCamera.closeMe()` function (and similarly for DialogScreen-Download) isn't properly bound to the `this` context.
- This is because the `closeMe.bind(this)` call is done in the parent class (DialogScreen) constructor, but the constructor isn't being called.
- This is because Babel doesn't properly transpile the `super()` call into a way that works on IE10 and below: https://phabricator.babeljs.io/T3041

Solution: Make the `super()`call redundant by making sure the parent's (DialogScreen's) constructor is also called in the childrens' (DialogScreen-ViewCamera, DialogScreen-Download) constructors.

NOTE: Screw DialogScreen-Species, it's being made redundant in PR #209 

Tested on IE10/Edge + Win7 (VirtualBox), Chrome50 + OSX

Status: Ready for review, @simoneduca and @eatyourgreens , but mind you, I'm doing some extra tests on IE10 and Edge to see what else if effing up.
