### PR TITLE
Update webpack, stylus deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,9 @@
     "rimraf": "^2.4.3",
     "stats-webpack-plugin": "^0.2.2",
     "style-loader": "^0.13.0",
-    "stylus-loader": "^1.4.2",
-    "webpack": "^1.12.9",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^2.1.0",
+    "webpack": "^1.13.1",
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.6.0"
   }


### PR DESCRIPTION
This updates webpack to 1.13, which suppresses all the deprecated warnings. It also required a stylus-loader bump, which in turn needed an explicit stylus install.
