### PR TITLE
Improve New Assignment creation process

### DIFF
--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -378,10 +378,9 @@ class MapControls extends Component {
           sessionStorage.setItem('savedSubjectsLocations', json.rows.map(i => i.location).join(','));
           sessionStorage.setItem('savedSubjectsIDs', json.rows.map(i => i.subject_id).join(','));
           
-          const classroomId = sessionStorage.getItem('savedClassroomId');
-          
+          const classroomId = sessionStorage.getItem('savedClassroomId');          
           if (classroomId) {
-            browserHistory.push('/teachers/classrooms/${classroomId}/assignment');
+            browserHistory.push(`/teachers/classrooms/${classroomId}/assignment`);
           } else {
             this.setState({
               generalDialog: {
@@ -389,8 +388,6 @@ class MapControls extends Component {
                 message: 'Subjects saved! Go to Classrooms to create your Assignment.'
             }});  
           }
-          
-          
         }
       })
       .catch((err) => {

--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -377,11 +377,20 @@ class MapControls extends Component {
         if (json && json.rows) {
           sessionStorage.setItem('savedSubjectsLocations', json.rows.map(i => i.location).join(','));
           sessionStorage.setItem('savedSubjectsIDs', json.rows.map(i => i.subject_id).join(','));
-          this.setState({
-            generalDialog: {
-              status: DialogScreen.DIALOG_ACTIVE,
-              message: 'Subjects saved! Go to Classrooms to create your Assignment.'
-          }});
+          
+          const classroomId = sessionStorage.getItem('savedClassroomId');
+          
+          if (classroomId) {
+            browserHistory.push('/teachers/classrooms/${classroomId}/assignment');
+          } else {
+            this.setState({
+              generalDialog: {
+                status: DialogScreen.DIALOG_ACTIVE,
+                message: 'Subjects saved! Go to Classrooms to create your Assignment.'
+            }});  
+          }
+          
+          
         }
       })
       .catch((err) => {

--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -60,11 +60,16 @@ export function createAssignment(assignment, classroomId) {
     })
     .then(response => response.json())
     .then(json => {
+      console.log('!'.repeat(40));
+      console.log(json);
+      console.log('!'.repeat(80));
+      console.log(json.data);
       dispatch({
         type: types.CREATE_ASSIGNMENT_SUCCESS,
         data: json.data,
       });
-      browserHistory.push( '/assignments/' + json.data.id);
+      browserHistory.push( `/teachers/classrooms/${json.data.attributes.classroom_id}`);
+      alert('Assignment created!');  //TODO: we need better messaging
     })
     .catch(response => console.log('RESPONSE-error: ', response));
   };

--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -60,10 +60,6 @@ export function createAssignment(assignment, classroomId) {
     })
     .then(response => response.json())
     .then(json => {
-      console.log('!'.repeat(40));
-      console.log(json);
-      console.log('!'.repeat(80));
-      console.log(json.data);
       dispatch({
         type: types.CREATE_ASSIGNMENT_SUCCESS,
         data: json.data,

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -1,5 +1,5 @@
 import { Component, PropTypes } from 'react';
-import { Link } from 'react-router';
+import { Link, browserHistory } from 'react-router';
 
 import InputElement from './InputElement';
 
@@ -19,8 +19,18 @@ class AssignmentForm extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.renderStudentList = this.renderStudentList.bind(this);
+    this.selectNewSubjects = this.selectNewSubjects.bind(this);
     this.toggleStudent = this.toggleStudent.bind(this);
-    this.state = Object.assign({}, initialState);
+    
+    const savedNewAssignments = (sessionStorage.getItem('savedNewAssignment'))
+      ? JSON.parse(sessionStorage.getItem('savedNewAssignment'))
+      : {};
+    
+    this.state = Object.assign( {}, initialState, savedNewAssignments);
+    
+    console.log('HELLO'.repeat(80));
+    console.log(savedNewAssignments);
+    
   }
 
   toggleStudent(e) {
@@ -63,7 +73,7 @@ class AssignmentForm extends Component {
     //WildCam Gorongosa has no Staging data that we can use to create Subjects.
     //Therefore, we need to hardcode some Subject IDs.
     //--------
-    /*if (window.location.hostname === 'localhost') {
+    if (window.location.hostname === 'localhost') {
       newAssignment.subjects = [
           '4077',
           '4079',
@@ -72,7 +82,7 @@ class AssignmentForm extends Component {
           '4080',
           '4075'
         ];
-    }*/
+    }
     //--------
     
     //NOTE: According to Marten, it's perfectly OK to create a subject with no students or subjects.
@@ -91,18 +101,25 @@ class AssignmentForm extends Component {
         {(students.length > 0) ?
         <table className="table table-hover">
           <tbody>
-            {students.map((student) =>
-            <tr
-              className={this.state.students.find(id => id === student.id) ? 'success' : ''}
-              key={student.id}
-            >
-              <td>
-                <label><input type="checkbox" value={student.id} onChange={this.toggleStudent} />
-                {student.attributes.zooniverse_display_name}
-                </label>
-              </td>
-            </tr>
-            )}
+            {students.map((student) => {
+              const selected = this.state.students.find(id => id === student.id);
+              return (
+                <tr
+                  className={selected ? 'success' : ''}
+                  key={student.id}
+                >
+                  <td>
+                    <label>
+                      {(selected)
+                        ? <input type="checkbox" value={student.id} onChange={this.toggleStudent} checked />
+                        : <input type="checkbox" value={student.id} onChange={this.toggleStudent} />
+                      }
+                      {student.attributes.zooniverse_display_name}
+                    </label>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         : 'No students here' }
@@ -136,9 +153,13 @@ class AssignmentForm extends Component {
         <ul className="subjects-preview">
           {subjectsHtml}
         </ul>
-        <Link className="form-group" to="/teachers/data">Select Subjects</Link>
       </div>
     );
+  }
+  
+  selectNewSubjects() {
+    sessionStorage.setItem('savedNewAssignment', JSON.stringify(this.state));
+    browserHistory.push('/teachers/data');
   }
 
   render() {
@@ -191,6 +212,9 @@ class AssignmentForm extends Component {
         </div>
         <div className="form-group">
           {this.renderSelectedSubjects()}
+        </div>
+        <div className="form-group">
+          <a className="btn" onClick={this.selectNewSubjects}>Select new images</a>
         </div>
         <div className="form-group">
           <button type="submit" className="btn btn-primary pull-right">Submit</button>

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -80,7 +80,7 @@ class AssignmentForm extends Component {
           '4078',
           '4076',
           '4080',
-          '4075'
+          '4075',
         ];
     }
     //--------
@@ -104,10 +104,7 @@ class AssignmentForm extends Component {
             {students.map((student) => {
               const selected = this.state.students.find(id => id === student.id);
               return (
-                <tr
-                  className={selected ? 'success' : ''}
-                  key={student.id}
-                >
+                <tr className={selected ? 'success' : ''} key={student.id}>
                   <td>
                     <label>
                       {(selected)
@@ -159,6 +156,7 @@ class AssignmentForm extends Component {
   
   selectNewSubjects() {
     sessionStorage.setItem('savedNewAssignment', JSON.stringify(this.state));
+    sessionStorage.setItem('savedClassroomId', this.props.params.classroomId);
     browserHistory.push('/teachers/data');
   }
 

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -81,11 +81,13 @@ class AssignmentForm extends Component {
     }
     //--------
     
-    //NOTE: According to Marten, it's perfectly OK to create a subject with no students or subjects.
+    //NOTE: According to Marten, it's perfectly OK to create an assignment with no students or subjects.
     //--------
     if (newAssignment.students.length > 0 && newAssignment.subjects.length) {
-      sessionStorage.setItem('savedNewAssignment', null);
-      sessionStorage.setItem('savedClassroomId', null);
+      sessionStorage.removeItem('savedNewAssignment');
+      sessionStorage.removeItem('savedClassroomId');      
+      sessionStorage.removeItem('savedSubjectsLocations');
+      sessionStorage.removeItem('savedSubjectsIDs');
       this.props.submitForm(newAssignment, this.props.params.classroomId)
     } else {
       alert('You can\'t create an assignment without students or subjects.')

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -26,11 +26,7 @@ class AssignmentForm extends Component {
       ? JSON.parse(sessionStorage.getItem('savedNewAssignment'))
       : {};
     
-    this.state = Object.assign( {}, initialState, savedNewAssignments);
-    
-    console.log('HELLO'.repeat(80));
-    console.log(savedNewAssignments);
-    
+    this.state = Object.assign( {}, initialState, savedNewAssignments);    
   }
 
   toggleStudent(e) {
@@ -88,6 +84,8 @@ class AssignmentForm extends Component {
     //NOTE: According to Marten, it's perfectly OK to create a subject with no students or subjects.
     //--------
     if (newAssignment.students.length > 0 && newAssignment.subjects.length) {
+      sessionStorage.setItem('savedNewAssignment', null);
+      sessionStorage.setItem('savedClassroomId', null);
       this.props.submitForm(newAssignment, this.props.params.classroomId)
     } else {
       alert('You can\'t create an assignment without students or subjects.')

--- a/src/modules/teachers/containers/ClassroomContainer.jsx
+++ b/src/modules/teachers/containers/ClassroomContainer.jsx
@@ -13,8 +13,8 @@ class ClassroomContainer extends Component {
     const { classrooms, assignments, params, actions } = this.props;
     const members = classrooms.members;
     const classroom = classrooms.data.find(classroom => classroom.id === params.classroomId);
-    //TODO: Select only assignments related to this Classroom
-    const classroomAssignments = assignments.data;
+    const classroomAssignments = assignments.data.filter(assignment =>
+      assignment.attributes.classroom_id === parseInt(params.classroomId));
     const classroomId = (classroom && classroom.id) ? classroom.id : undefined;
     const boundDeleteClassroom = actions.deleteClassroom.bind(this, classroomId);
     const students = classroom ? classroom.relationships.students.data : undefined;

--- a/src/reducers/assignment.js
+++ b/src/reducers/assignment.js
@@ -13,12 +13,14 @@ export function assignment(state = initialState, action) {
     case types.CREATE_ASSIGNMENT:
       return { ...state,
         assignments: {
-          data: state.assignments,
+          data: state.assignments.data,
           error: false,
           loading: true,
         }
       };
     case types.CREATE_ASSIGNMENT_SUCCESS:
+      console.log('*'.repeat(40));
+      console.log(state);
       const newlist = state.assignments.data.concat(action.data);
       return { ...state,
         assignments: {

--- a/src/reducers/assignment.js
+++ b/src/reducers/assignment.js
@@ -19,8 +19,6 @@ export function assignment(state = initialState, action) {
         }
       };
     case types.CREATE_ASSIGNMENT_SUCCESS:
-      console.log('*'.repeat(40));
-      console.log(state);
       const newlist = state.assignments.data.concat(action.data);
       return { ...state,
         assignments: {


### PR DESCRIPTION
Intended Features: what it says on the tin.
- Refer to Method 1 in #226
- When a Teacher is Classrooms choosing to create a New Assignment,
  - She should be able to transition to the Map Explorer easily
  - then transition back to the New Assignment form (with all details stored)
  - then be properly notified that the Assignment is created.

Code Specifics:
- [x] `teachers/components/AssignmentForm.jsx` loads saved NewAssignment data on transition in.
- [x] `teachers/components/AssignmentForm.jsx` saves NewAssignment data on transition out to Map Explorer.
- [x] ...as well as the Classroom ID
- [x] Upon choosing "use Subjects for Assignment", Map Explorer redirects back to New Assignment form **if** it knows what Classroom ID it should push back to.
- [x] ...what to do when no Classroom ID specified? Consider. (UPDATE: we stick with the old "pls go 2 assignment pg" message)
- [x] `teachers/components/AssignmentForm.jsx` gives a proper success/error message upon the creation of an Assignment (UPDATE: we're using an `alert()`...)
- [x] ...and transitions users back to the respective Classroom page.
