### PR TITLE
Map Explorer (Episode 1) - Add Time of Day, Dist to Water, Dist to Humans filters

### DIFF
--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -86,11 +86,6 @@
       "displayName": "Elephants"
     },
     {
-      "id": "fire",
-      "dbName": "Fire",
-      "displayName": "Fire!"
-    },
-    {
       "id": "genet",
       "dbName": "Genet",
       "displayName": "Genets"
@@ -119,11 +114,6 @@
       "id": "hbadger",
       "dbName": "Honey Badger",
       "displayName": "Honey Badgers"
-    },
-    {
-      "id": "human",
-      "dbName": "Human",
-      "displayName": "Humans"
     },
     {
       "id": "hyena",
@@ -169,11 +159,6 @@
       "id": "mongoose",
       "dbName": "Mongoose",
       "displayName": "Mongoose"
-    },
-    {
-      "id": "nothing",
-      "dbName": "Nothing here",
-      "displayName": "(Nothing)"
     },
     {
       "id": "nyala",
@@ -284,6 +269,21 @@
       "id": "zebra",
       "dbName": "Zebra",
       "displayName": "Zebras"
+    },
+    {
+      "id": "human",
+      "dbName": "Human",
+      "displayName": "Humans"
+    },
+    {
+      "id": "fire",
+      "dbName": "Fire",
+      "displayName": "Fire!"
+    },
+    {
+      "id": "nothing",
+      "dbName": "Nothing here",
+      "displayName": "(Nothing)"
     }
   ],
   "habitats": [
@@ -329,5 +329,35 @@
       "dbName": "DryWet Oct-Dec",
       "displayName": "Dry-Wet (Oct-Dec)"
     }
-  ]
+  ],
+  "timesOfDay": [
+    {
+      "id": "dawn",
+      "dbName": "Dawn 0557-0622",
+      "displayName": "Dawn (0557 - 0622)"
+    },
+    {
+      "id": "day",
+      "dbName": "Day 0623-1709",
+      "displayName": "Day (0623 - 1709)"
+    },
+    {
+      "id": "dusk",
+      "dbName": "Dusk 1710-1735",
+      "displayName": "Dusk (1710 - 1735)"
+    },
+    {
+      "id": "night",
+      "dbName": "Night 1736-0556",
+      "displayName": "Night (1736 - 0556)"
+    }
+  ],
+  "distanceToHumans": {
+    "min": 0,
+    "max": 8949
+  },
+  "distanceToWater": {
+    "min": 0,
+    "max": 3786
+  }
 }

--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -78,6 +78,17 @@ class MapControls extends Component {
         </li>
       );
     });
+    
+    //Input Choice: Times of Day
+    let timesOfDay = [];
+    config.timesOfDay.map((item) => {
+      timesOfDay.push(
+        <li key={`timesOfDay_${item.id}`}>
+          <input type="checkbox" id={`inputRow_timesOfDay_item_${item.id}_${thisId}`} ref={`inputRow_timesOfDay_item_${item.id}`} value={item.id} />
+          <label htmlFor={`inputRow_timesOfDay_item_${item.id}_${thisId}`}>{item.displayName}</label>
+        </li>
+      );
+    });
 
     //Subpanel Switching
     const subPanelGuidedClass = (this.props.selectorData.mode !== MapSelector.GUIDED_MODE)
@@ -93,7 +104,7 @@ class MapControls extends Component {
         <section className={subPanelGuidedClass} ref="subPanel_guided">
           <button className="btn hidden" onClick={this.changeToGuided}>Standard Mode</button>
           <div className="input-row">
-            <label>SPECIES:</label>
+            <label>Species</label>
             {
               (speciesText.length > 0)
               ? <span>Viewing {speciesText}</span>
@@ -101,7 +112,6 @@ class MapControls extends Component {
             }
           </div>
           <div className="input-row" ref="inputRow_species">
-            <label>Species</label>
             <ul>
               {species}
             </ul>
@@ -124,6 +134,28 @@ class MapControls extends Component {
               <input ref="inputRow_dates_item_start" placeholder="2000-12-31" />
               <span>to</span>
               <input ref="inputRow_dates_item_end" placeholder="2020-12-31" />
+            </div>
+          </div>
+          <div className="input-row" ref="inputRow_timesOfDay">
+            <label>Times of Day</label>
+            <ul>
+              {timesOfDay}
+            </ul>
+          </div>
+          <div className="input-row">
+            <label>Distance to Humans (m)</label>
+            <div className="range-input">
+              <input ref="inputRow_distanceToHumans_item_start" placeholder={config.distanceToHumans.min} />
+              <span>to</span>
+              <input ref="inputRow_distanceToHumans_item_end" placeholder={config.distanceToHumans.max} />
+            </div>
+          </div>
+          <div className="input-row">
+            <label>Distance to Water (m)</label>
+            <div className="range-input">
+              <input ref="inputRow_distanceToWater_item_start" placeholder={config.distanceToWater.min} />
+              <span>to</span>
+              <input ref="inputRow_distanceToWater_item_end" placeholder={config.distanceToWater.max} />
             </div>
           </div>
           <div className="input-row hidden">
@@ -182,6 +214,13 @@ class MapControls extends Component {
     });
     this.refs['inputRow_dates_item_start'].value = this.props.selectorData.dateStart;
     this.refs['inputRow_dates_item_end'].value = this.props.selectorData.dateEnd;
+    config.timesOfDay.map((item) => {
+      this.refs[`inputRow_timesOfDay_item_${item.id}`].checked = (this.props.selectorData.timesOfDay.indexOf(item.id) >= 0);
+    });    
+    this.refs['inputRow_distanceToHumans_item_start'].value = this.props.selectorData.distanceToHumansMin;
+    this.refs['inputRow_distanceToHumans_item_end'].value = this.props.selectorData.distanceToHumansMax;
+    this.refs['inputRow_distanceToWater_item_start'].value = this.props.selectorData.distanceToWaterMin;
+    this.refs['inputRow_distanceToWater_item_end'].value = this.props.selectorData.distanceToWaterMax;
 
     //Some extra options
     this.refs.username.value = this.props.selectorData.user;
@@ -277,6 +316,23 @@ class MapControls extends Component {
     //Filter control: dates
     data.dateStart = this.refs['inputRow_dates_item_start'].value.trim();
     data.dateEnd = this.refs['inputRow_dates_item_end'].value.trim();
+    
+    //Filter control: times of day
+    data.timesOfDay = [];
+    config.timesOfDay.map((item) => {
+      const ele = this.refs[`inputRow_timesOfDay_item_${item.id}`];
+      if (ele && ele.checked && ele.value) {
+        data.timesOfDay.push(item.id);
+      }
+    });
+    
+    //Filter control: distance to humans
+    data.distanceToHumansMin = this.refs['inputRow_distanceToHumans_item_start'].value.trim();
+    data.distanceToHumansMax = this.refs['inputRow_distanceToHumans_item_end'].value.trim();
+    
+    //Filter control: distance to water
+    data.distanceToWaterMin = this.refs['inputRow_distanceToWater_item_start'].value.trim();
+    data.distanceToWaterMax = this.refs['inputRow_distanceToWater_item_end'].value.trim();
 
     //Filter control: users & grouping
     data.user = this.refs.username.value.trim();

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -1,10 +1,3 @@
-//SHAUN'S TEMPORARY NOTES
-//If you see this in the PR, yell at me
-//dist_humans_m - 8949
-//dist_water_m - 3786
-//time_period - 'Day 0623-1709', 'Night 1736-0556', 'Dusk 1710-1735', 'Dawn 0557-0622' ;
-//timeutc
-
 const config = require('../../../constants/mapExplorer.config.json');
 
 class MapSelector {


### PR DESCRIPTION
Features:
- Users of the Map Explorer can now filter results by...
  - Time of Day (Dawn, Day, Dusk, Night)
  - Distance to Water
  - Distance to Humans

This addresses _"Add filters for: time of day (day, night, dawn, dusk); distance to human structure, distance to water source. TOP-PRIORITY."_ in #242 

This is the basic version (no fancy UI), so [you get a textbox, you get a textbox, you get a textbox, _everybody_ gets a textbox.](https://youtu.be/8CAscBCdaQg?t=1m32s)

Ready for review!
