### PR TITLE
Map Explorer (Episode 2) - "Easy Mode" for CSV Downloads

### DIFF
--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -11,13 +11,23 @@
     "sqlQueryDownload": "SELECT cameras.*, items.* FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.* FROM {SUBJECTS} as a INNER JOIN (SELECT * FROM {AGGREGATIONS} WHERE num_classifications >= 5) as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 10000",
     "sqlQuerySubjectIDs": "SELECT items.subject_id, items.location FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.* FROM {SUBJECTS} as a INNER JOIN (SELECT * FROM {AGGREGATIONS} WHERE num_classifications >= 5) as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 100",
     "cssStandard": "#{LAYER} { marker-fill: {MARKERCOLOR}; marker-fill-opacity: {MARKEROPACITY}; marker-width: {MARKERSIZE}; marker-line-color: #FFF; marker-line-width: 1; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-allow-overlap: true; {CHILDREN} }",
-    "csvTranslator": {
+    "csvEasyModeTranslator": {
       "subject_id": "image_id",
+      "camera": "camera",
+      "longitude": "longitude",
+      "latitude": "latitude",
       "dateutc": "date",
+      "month": "month",
+      "year": "year",
+      "season": "season",
+      "time_period": "time_period",
+      "veg_type": "veg_type",
       "human_type": "human_structure",
       "dist_humans_m": "distance_human_m",
+      "water_type": "water_type",
       "dist_water_m": "distance_water_m",
-      "ost_likely_number_of_animals": "species_count",
+      "species": "species",
+      "most_likely_number_of_animals": "species_count",
       "percentage_behaviour_resting": "percentage_resting",
       "percentage_behaviour_standing": "percentage_standing",
       "percentage_behaviour_moving": "percentage_moving",
@@ -25,9 +35,7 @@
       "percentage_behaviour_interacting": "percentage_interacting",
       "most_likely_are_there_any_young_present": "young_present",
       "percentage_do_you_see_any_hornsyes": "horns",
-      "location": "image_url",
-      "cartodb_id": "database_id",
-      "id": "camera_id"
+      "location": "image_url"
     }
   },
   "mapCentre": {

--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -86,11 +86,6 @@
       "displayName": "Elephants"
     },
     {
-      "id": "fire",
-      "dbName": "Fire",
-      "displayName": "Fire!"
-    },
-    {
       "id": "genet",
       "dbName": "Genet",
       "displayName": "Genets"
@@ -119,11 +114,6 @@
       "id": "hbadger",
       "dbName": "Honey Badger",
       "displayName": "Honey Badgers"
-    },
-    {
-      "id": "human",
-      "dbName": "Human",
-      "displayName": "Humans"
     },
     {
       "id": "hyena",
@@ -169,11 +159,6 @@
       "id": "mongoose",
       "dbName": "Mongoose",
       "displayName": "Mongoose"
-    },
-    {
-      "id": "nothing",
-      "dbName": "Nothing here",
-      "displayName": "(Nothing)"
     },
     {
       "id": "nyala",
@@ -284,6 +269,21 @@
       "id": "zebra",
       "dbName": "Zebra",
       "displayName": "Zebras"
+    },
+    {
+      "id": "human",
+      "dbName": "Human",
+      "displayName": "Humans"
+    },
+    {
+      "id": "fire",
+      "dbName": "Fire",
+      "displayName": "Fire!"
+    },
+    {
+      "id": "nothing",
+      "dbName": "Nothing here",
+      "displayName": "(Nothing)"
     }
   ],
   "habitats": [
@@ -329,5 +329,35 @@
       "dbName": "DryWet Oct-Dec",
       "displayName": "Dry-Wet (Oct-Dec)"
     }
-  ]
+  ],
+  "timesOfDay": [
+    {
+      "id": "dawn",
+      "dbName": "Dawn 0557-0622",
+      "displayName": "Dawn (0557 - 0622)"
+    },
+    {
+      "id": "day",
+      "dbName": "Day 0623-1709",
+      "displayName": "Day (0623 - 1709)"
+    },
+    {
+      "id": "dusk",
+      "dbName": "Dusk 1710-1735",
+      "displayName": "Dusk (1710 - 1735)"
+    },
+    {
+      "id": "night",
+      "dbName": "Night 1736-0556",
+      "displayName": "Night (1736 - 0556)"
+    }
+  ],
+  "distanceToHumans": {
+    "min": 0,
+    "max": 8949
+  },
+  "distanceToWater": {
+    "min": 0,
+    "max": 3786
+  }
 }

--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -10,7 +10,25 @@
     "sqlQueryViewCamera": "SELECT DISTINCT location FROM (SELECT cam.latitude, cam.longitude, cam.veg_type, cam.dist_humans_m, cam.human_type, cam.dist_water_m, cam.water_type, sbj.* FROM {CAMERAS} as cam INNER JOIN {SUBJECTS} as sbj ON cam.id = sbj.camera) as camsbj INNER JOIN (SELECT * FROM {AGGREGATIONS} WHERE num_classifications >= 5) as agg ON camsbj.subject_id = agg.subject_id {WHERE}",
     "sqlQueryDownload": "SELECT cameras.*, items.* FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.* FROM {SUBJECTS} as a INNER JOIN (SELECT * FROM {AGGREGATIONS} WHERE num_classifications >= 5) as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 10000",
     "sqlQuerySubjectIDs": "SELECT items.subject_id, items.location FROM {CAMERAS} AS cameras LEFT JOIN (SELECT a.camera, a.location, a.dateutc, a.month, a.year, a.season, a.time_period, b.* FROM {SUBJECTS} as a INNER JOIN (SELECT * FROM {AGGREGATIONS} WHERE num_classifications >= 5) as b ON a.subject_id = b.subject_id) AS items ON cameras.id = items.camera {WHERE} LIMIT 100",
-    "cssStandard": "#{LAYER} { marker-fill: {MARKERCOLOR}; marker-fill-opacity: {MARKEROPACITY}; marker-width: {MARKERSIZE}; marker-line-color: #FFF; marker-line-width: 1; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-allow-overlap: true; {CHILDREN} }"
+    "cssStandard": "#{LAYER} { marker-fill: {MARKERCOLOR}; marker-fill-opacity: {MARKEROPACITY}; marker-width: {MARKERSIZE}; marker-line-color: #FFF; marker-line-width: 1; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-allow-overlap: true; {CHILDREN} }",
+    "csvTranslator": {
+      "subject_id": "image_id",
+      "dateutc": "date",
+      "human_type": "human_structure",
+      "dist_humans_m": "distance_human_m",
+      "dist_water_m": "distance_water_m",
+      "ost_likely_number_of_animals": "species_count",
+      "percentage_behaviour_resting": "percentage_resting",
+      "percentage_behaviour_standing": "percentage_standing",
+      "percentage_behaviour_moving": "percentage_moving",
+      "percentage_behaviour_eating": "percentage_eating",
+      "percentage_behaviour_interacting": "percentage_interacting",
+      "most_likely_are_there_any_young_present": "young_present",
+      "percentage_do_you_see_any_hornsyes": "horns",
+      "location": "image_url",
+      "cartodb_id": "database_id",
+      "id": "camera_id"
+    }
   },
   "mapCentre": {
     "latitude": -18.9278,

--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -378,12 +378,17 @@ class MapControls extends Component {
         let data = [];
         let row = [];
 
+        //Prepare the column headers
+        //NOTE: we can package these translations into the SQL query but it'll get super long & messy
         for (let key in json.fields) {
-          row.push('"'+key.replace(/"/g, '\\"')+'"');
+          const columnName =  config.cartodb.csvTranslator[key] || key;
+          console.log(key, '...', columnName);
+          row.push('"'+columnName.replace(/"/g, '\\"')+'"');
         }
         row = row.join(',');
         data.push(row);
-
+      
+        //Prepare each row of data
         json.rows.map((rowItem) => {
           let row = [];
           for (let key in json.fields) {

--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -9,7 +9,6 @@ import DialogScreen from '../components/DialogScreen';
 import DialogScreen_Download from '../components/DialogScreen-Download';
 const config = require('../../../constants/mapExplorer.config.json');
 
-
 class MapControls extends Component {
   constructor(props) {
     super(props);
@@ -377,29 +376,54 @@ class MapControls extends Component {
       .then((json) => {
         let data = [];
         let row = [];
-
-        //Prepare the column headers
-        //NOTE: we can package these translations into the SQL query but it'll get super long & messy
-        for (let key in json.fields) {
-          const columnName =  config.cartodb.csvTranslator[key] || key;
-          console.log(key, '...', columnName);
-          row.push('"'+columnName.replace(/"/g, '\\"')+'"');
-        }
-        row = row.join(',');
-        data.push(row);
+        
+        const EASYMODE = true;  //Instead of giving the full raw data, we can
+                                //give students a smaller, more easy-to-read
+                                //version. //TODO: Enable users to toggle.
       
-        //Prepare each row of data
-        json.rows.map((rowItem) => {
-          let row = [];
-          for (let key in json.fields) {
-            (json.fields[key].type === 'string' && rowItem[key])
-              ? row.push('"'+rowItem[key].replace(/"/g, '\\"')+'"')
-              : row.push(rowItem[key]);
+        if (EASYMODE) {
+          //Prepare the column headers
+          //NOTE: we can package these translations into the SQL query but it'll get super long & messy
+          for (let key in config.cartodb.csvEasyModeTranslator) {
+            row.push('"'+config.cartodb.csvEasyModeTranslator[key].replace(/"/g, '\\"')+'"');
           }
           row = row.join(',');
           data.push(row);
-        });
-        data = data.join('\n');
+          
+          //Prepare each row of data
+          json.rows.map((rowItem) => {
+            let row = [];
+            for (let key in config.cartodb.csvEasyModeTranslator) {
+              (json.fields[key].type === 'string' && rowItem[key])
+                ? row.push('"'+rowItem[key].replace(/"/g, '\\"')+'"')
+                : row.push(rowItem[key]);
+            }
+            row = row.join(',');
+            data.push(row);
+          });
+          data = data.join('\n');
+        } else {
+          //Prepare the column headers
+          //NOTE: we can package these translations into the SQL query but it'll get super long & messy
+          for (let key in json.fields) {
+            row.push('"'+key.replace(/"/g, '\\"')+'"');
+          }
+          row = row.join(',');
+          data.push(row);
+
+          //Prepare each row of data
+          json.rows.map((rowItem) => {
+            let row = [];
+            for (let key in json.fields) {
+              (json.fields[key].type === 'string' && rowItem[key])
+                ? row.push('"'+rowItem[key].replace(/"/g, '\\"')+'"')
+                : row.push(rowItem[key]);
+            }
+            row = row.join(',');
+            data.push(row);
+          });
+          data = data.join('\n');
+        }
 
         this.setState({
           downloadDialog: {

--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -78,6 +78,17 @@ class MapControls extends Component {
         </li>
       );
     });
+    
+    //Input Choice: Times of Day
+    let timesOfDay = [];
+    config.timesOfDay.map((item) => {
+      timesOfDay.push(
+        <li key={`timesOfDay_${item.id}`}>
+          <input type="checkbox" id={`inputRow_timesOfDay_item_${item.id}_${thisId}`} ref={`inputRow_timesOfDay_item_${item.id}`} value={item.id} />
+          <label htmlFor={`inputRow_timesOfDay_item_${item.id}_${thisId}`}>{item.displayName}</label>
+        </li>
+      );
+    });
 
     //Subpanel Switching
     const subPanelGuidedClass = (this.props.selectorData.mode !== MapSelector.GUIDED_MODE)
@@ -93,7 +104,7 @@ class MapControls extends Component {
         <section className={subPanelGuidedClass} ref="subPanel_guided">
           <button className="btn hidden" onClick={this.changeToGuided}>Standard Mode</button>
           <div className="input-row">
-            <label>SPECIES:</label>
+            <label>Species</label>
             {
               (speciesText.length > 0)
               ? <span>Viewing {speciesText}</span>
@@ -101,7 +112,6 @@ class MapControls extends Component {
             }
           </div>
           <div className="input-row" ref="inputRow_species">
-            <label>Species</label>
             <ul>
               {species}
             </ul>
@@ -124,6 +134,28 @@ class MapControls extends Component {
               <input ref="inputRow_dates_item_start" placeholder="2000-12-31" />
               <span>to</span>
               <input ref="inputRow_dates_item_end" placeholder="2020-12-31" />
+            </div>
+          </div>
+          <div className="input-row" ref="inputRow_timesOfDay">
+            <label>Times of Day</label>
+            <ul>
+              {timesOfDay}
+            </ul>
+          </div>
+          <div className="input-row">
+            <label>Distance to Humans (m)</label>
+            <div className="range-input">
+              <input ref="inputRow_distanceToHumans_item_start" placeholder={config.distanceToHumans.min} />
+              <span>to</span>
+              <input ref="inputRow_distanceToHumans_item_end" placeholder={config.distanceToHumans.max} />
+            </div>
+          </div>
+          <div className="input-row">
+            <label>Distance to Water (m)</label>
+            <div className="range-input">
+              <input ref="inputRow_distanceToWater_item_start" placeholder={config.distanceToWater.min} />
+              <span>to</span>
+              <input ref="inputRow_distanceToWater_item_end" placeholder={config.distanceToWater.max} />
             </div>
           </div>
           <div className="input-row hidden">
@@ -182,6 +214,13 @@ class MapControls extends Component {
     });
     this.refs['inputRow_dates_item_start'].value = this.props.selectorData.dateStart;
     this.refs['inputRow_dates_item_end'].value = this.props.selectorData.dateEnd;
+    config.timesOfDay.map((item) => {
+      this.refs[`inputRow_timesOfDay_item_${item.id}`].checked = (this.props.selectorData.timesOfDay.indexOf(item.id) >= 0);
+    });    
+    this.refs['inputRow_distanceToHumans_item_start'].value = this.props.selectorData.distanceToHumansMin;
+    this.refs['inputRow_distanceToHumans_item_end'].value = this.props.selectorData.distanceToHumansMax;
+    this.refs['inputRow_distanceToWater_item_start'].value = this.props.selectorData.distanceToWaterMin;
+    this.refs['inputRow_distanceToWater_item_end'].value = this.props.selectorData.distanceToWaterMax;
 
     //Some extra options
     this.refs.username.value = this.props.selectorData.user;
@@ -277,6 +316,23 @@ class MapControls extends Component {
     //Filter control: dates
     data.dateStart = this.refs['inputRow_dates_item_start'].value.trim();
     data.dateEnd = this.refs['inputRow_dates_item_end'].value.trim();
+    
+    //Filter control: times of day
+    data.timesOfDay = [];
+    config.timesOfDay.map((item) => {
+      const ele = this.refs[`inputRow_timesOfDay_item_${item.id}`];
+      if (ele && ele.checked && ele.value) {
+        data.timesOfDay.push(item.id);
+      }
+    });
+    
+    //Filter control: distance to humans
+    data.distanceToHumansMin = this.refs['inputRow_distanceToHumans_item_start'].value.trim();
+    data.distanceToHumansMax = this.refs['inputRow_distanceToHumans_item_end'].value.trim();
+    
+    //Filter control: distance to water
+    data.distanceToWaterMin = this.refs['inputRow_distanceToWater_item_start'].value.trim();
+    data.distanceToWaterMax = this.refs['inputRow_distanceToWater_item_end'].value.trim();
 
     //Filter control: users & grouping
     data.user = this.refs.username.value.trim();

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -1,10 +1,3 @@
-//SHAUN'S TEMPORARY NOTES
-//If you see this in the PR, yell at me
-//dist_humans_m - 8949
-//dist_water_m - 3786
-//time_period - 'Day 0623-1709', 'Night 1736-0556', 'Dusk 1710-1735', 'Dawn 0557-0622' ;
-//timeutc
-
 const config = require('../../../constants/mapExplorer.config.json');
 
 class MapSelector {


### PR DESCRIPTION
Features:
- Users have reported that the CSV downloads are too complicated and user-unfriendly.
- An "Easy Mode" was added to `prepareCSV()` that customises the CSV download to more accurately match the user's requested type of CSV, which would be easier to be digested by students.
- Easy Mode replaces the Download CSV function; TODO: build a toggle that re-enables the Full Mode CSV data.

Closes #245 

Ready for review, but please either...
- merge #244 first then review this second,
- OR ignore #244 and merge this as a "combined merge". (This branch is based on 244's branch.)

Sample CSV attached: [wildcam-26jul2016-new-header-sample.txt](https://github.com/zooniverse/wildcam-gorongosa-education/files/383875/wildcam-26jul2016-new-header-sample.txt)
