### PR TITLE
Map Explorer - JSON Description for "Select Subjects for Assignment"

### DIFF
--- a/src/modules/common/containers/MapControls.jsx
+++ b/src/modules/common/containers/MapControls.jsx
@@ -466,6 +466,7 @@ class MapControls extends Component {
         if (json && json.rows) {
           sessionStorage.setItem('savedSubjectsLocations', json.rows.map(i => i.location).join(','));
           sessionStorage.setItem('savedSubjectsIDs', json.rows.map(i => i.subject_id).join(','));
+          sessionStorage.setItem('savedSubjectsDescription', JSON.stringify(data.toJson()));
           
           const classroomId = sessionStorage.getItem('savedClassroomId');          
           if (classroomId) {

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -173,6 +173,18 @@ class MapSelector {
     }
     return newCopy;
   }
+  
+  toJson() {
+    let json = {};
+    const selectorKeys = ['species', 'habitats', 'seasons',
+                          'dateStart', 'dateEnd', 'timesOfDay',
+                          'distanceToHumansMin', 'distanceToHumansMax',
+                          'distanceToWaterMin', 'distanceToWaterMax'];
+    for (let key of selectorKeys) {
+      if (this[key] && this[key].length > 0) { json[key] = this[key]; }
+    }
+    return json;
+  }
 }
 
 //The Map controls can be set to either Guided Mode (the default with UI widgets


### PR DESCRIPTION
For @simoneduca 
- When a Teacher clicks "Select of Assignment" in Map Explorer, a new data field is saved to session storage.
- To retrieve the data: `JSON.parse(sessionStorage.getItem('savedSubjectsDescription'))`
- The data type is a stringified JSON object, with sample values being...

```
//No filters options selected
{}
```

```
//Only species filters selected
{
  "species": [ "caracal","wildcat" ]
}
```

```
//All current filters options used
{
  "species": ["lioncub"],
  "habitats": ["floodplain","miombo"],
  "seasons": ["janmar", "julsep"],
  "dateStart": "2000-12-31",
  "dateEnd": "2020-12-31",
  "timesOfDay": ["dawn","dusk"],
  "distanceToHumansMin": "100",
  "distanceToHumansMax": "500",
  "distanceToWaterMin": "200",
  "distanceToWaterMax":"600"
}
```

Filter options will always be either Arrays of Strings, or Strings. The JSON object will only be 3 layers deep at max, as demonstrated in the samples above.

Note: please remember to add `sessionStorage.removeItem('savedSubjectsDescription')` on the Assignment side once you're done with the description.
