### PR TITLE
Map Explorer (Episode 4) - Improved GeoData Layers

### DIFF
--- a/src/map-data/gorongosa-geodata.json
+++ b/src/map-data/gorongosa-geodata.json
@@ -9,8 +9,8 @@
   },
   "options": {
     "style": {
-      "color": "#c93",
-      "opacity": 0.5,
+      "color": "#00ff00",
+      "opacity": 1,
       "clickable": false,
       "weight": 5
     }

--- a/src/map-data/gorongosa-geodata.json
+++ b/src/map-data/gorongosa-geodata.json
@@ -9,8 +9,9 @@
   },
   "options": {
     "style": {
-      "color": "#00ff00",
+      "color": "#fc3",
       "opacity": 1,
+      "fillOpacity": 0,
       "clickable": false,
       "weight": 5
     }

--- a/src/map-data/vegetation-geodata.json
+++ b/src/map-data/vegetation-geodata.json
@@ -29,11 +29,11 @@
     "Floodplain Grassland": { "color": "#3c9" },
     "Limestone Gorges": { "color": "#cc0" },
     
-    "Montane Woodland": { "color": "#c00" },
+    "Montane Woodland": { "color": "#c3c" },
     "Montane Forest": { "color": "#606" },
     "Montane Grassland": { "color": "#30c" },
     
     "Lake Urema": { "color": "#0ff" },
-    "Inselberg": { "color": "#c90" }
+    "Inselberg": { "color": "#f30" }
   }
 }

--- a/src/map-data/vegetation-geodata.json
+++ b/src/map-data/vegetation-geodata.json
@@ -16,10 +16,10 @@
   },
   "options": {
     "style": {
-      "color": "#9c6",
-      "opacity": 100,
+      "color": "#0000ff",
+      "opacity": 1,
       "clickable": false,
-      "weight": 0
+      "weight": 1
     }
   }
 }

--- a/src/map-data/vegetation-geodata.json
+++ b/src/map-data/vegetation-geodata.json
@@ -16,10 +16,24 @@
   },
   "options": {
     "style": {
-      "color": "#0000ff",
-      "opacity": 1,
+      "color": "#0f0",
+      "opacity": 0,
+      "fillOpacity": 0.2,
       "clickable": false,
-      "weight": 1
+      "weight": 0
     }
+  },
+  "specificStyles" : {
+    "Miombo Woodland": { "color": "#063" },
+    "Mixed Savanna and Woodland": { "color": "#693" },
+    "Floodplain Grassland": { "color": "#3c9" },
+    "Limestone Gorges": { "color": "#cc0" },
+    
+    "Montane Woodland": { "color": "#c00" },
+    "Montane Forest": { "color": "#606" },
+    "Montane Grassland": { "color": "#30c" },
+    
+    "Lake Urema": { "color": "#0ff" },
+    "Inselberg": { "color": "#c90" }
   }
 }

--- a/src/modules/common/components/MapLegendCameras.jsx
+++ b/src/modules/common/components/MapLegendCameras.jsx
@@ -1,0 +1,10 @@
+import { PropTypes } from 'react';
+
+const MapLegendCameras = (props) => (
+  <div className="info legend">
+    <div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#666" /></svg> : Camera with no images</div>
+    <div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#f93" /></svg> : Camera with images (click to view)</div>
+  </div>
+);
+
+export default MapLegendCameras;

--- a/src/modules/common/components/MapLegendVegetation.jsx
+++ b/src/modules/common/components/MapLegendVegetation.jsx
@@ -1,0 +1,21 @@
+import { PropTypes } from 'react';
+const vegetationGeodata = require('../../../map-data/vegetation-geodata.json');
+
+const MapLegendVegetation = (props) => {
+  let keys = [];
+  
+  for (let key in vegetationGeodata.specificStyles) {
+    const color = vegetationGeodata.specificStyles[key].color;
+    keys.push(
+      <div>
+        <svg height="10" width="10"><circle cx="5" cy="5" r="5" fill={color} fillOpacity="0.5" /></svg> : {key}
+      </div>);
+  }
+  return (
+    <div className="info legend">
+      {keys}
+    </div>
+  );
+};
+
+export default MapLegendVegetation;

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -27,9 +27,9 @@ class MapSelector {
     this.user = '';
 
     //Default marker styles.
-    this.markerColor = '#ff0000';  //'#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
+    this.markerColor = '#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
     this.markerSize = '15';
-    this.markerOpacity = '1.0';  //'0.8';
+    this.markerOpacity = '0.8';
 
     //These two are the most important values; they're derived from the selector
     //settings above.

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -27,9 +27,9 @@ class MapSelector {
     this.user = '';
 
     //Default marker styles.
-    this.markerColor = '#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
+    this.markerColor = '#ff0000';  //'#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
     this.markerSize = '15';
-    this.markerOpacity = '0.8';
+    this.markerOpacity = '1.0';  //'0.8';
 
     //These two are the most important values; they're derived from the selector
     //settings above.

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -92,8 +92,8 @@ class MapVisuals extends Component {
     
     //Create the CartoDB Data layer
     cartodb.createLayer(this.state.map, config.cartodb.vizUrl)
-      .addTo(this.state.map)
-      .on('done', (layer) => {
+      .done((layer) => {
+        layer.addTo(this.state.map);
         this.state.cartodbLayer = layer;
         this.state.cartodbLayer.setInteraction(true);
         layer.on('error', (err) => {
@@ -102,14 +102,16 @@ class MapVisuals extends Component {
 
         //Add the controls for the layers
         L.control.layers(baseLayersForControls, {
-          ...geomapLayers,
           'Data': layer,
+          ...geomapLayers
+        }, {
+          'collapsed': false,
         }).addTo(this.state.map);
 
         //updateDataVisualisation performs some cleanup
         this.updateDataVisualisation(this.props);
       })
-      .on('error', (err) => {
+      .error((err) => {
         console.error('ERROR (initMapExplorer(), cartodb.createLayer()):' + err);
       });
 

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -128,12 +128,25 @@ class MapVisuals extends Component {
     const legend = L.control({position: 'bottomright'});
     legend.onAdd = (map) => {
       const div = L.DomUtil.create('div', 'info legend');
-      div.innerHTML +=
+      div.innerHTML =
         '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#666" /></svg> : Camera with no images</div>' +
         '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#f93" /></svg> : Camera with images (click to view)</div>';
       return div;
     };
     legend.addTo(this.state.map);
+    
+    //Bonus: Add (vegetation) legends to map
+    const vegetationLegend = L.control({position: 'bottomright'});
+    vegetationLegend.onAdd = (map) => {
+      const div = L.DomUtil.create('div', 'info legend');
+      div.innerHTML = '<div>Vegetation types</div>';
+      for (let key in vegetationGeodata.specificStyles) {
+        const color = vegetationGeodata.specificStyles[key].color;
+        div.innerHTML += '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="'+color+'" fill-opacity="0.5" /></svg> : '+key+'</div>';
+      }
+      return div;
+    };
+    vegetationLegend.addTo(this.state.map);
 
     //Bonus: 'Recentre Map' button
     const recentreButton = L.control({position: 'topleft'});

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -87,7 +87,16 @@ class MapVisuals extends Component {
     //Create the CartoDB Geomap layer
     const geomapLayers = {
       'Gorongosa National Park': L.geoJson(gorongosaGeodata.geojson, gorongosaGeodata.options).addTo(this.state.map),
-      'Vegetation': L.geoJson(vegetationGeodata.geojson, vegetationGeodata.options).addTo(this.state.map),
+      'Vegetation': L.geoJson(vegetationGeodata.geojson, {
+        style: function (feature) {
+          const specificStyles = vegetationGeodata.specificStyles;
+          let baseStyle = vegetationGeodata.options.style;
+          const featureName = feature.properties.NAME;
+          return (specificStyles[featureName])
+            ? Object.assign(baseStyle, specificStyles[featureName])
+            : baseStyle;
+        }        
+      }).addTo(this.state.map),
     };
     
     //Create the CartoDB Data layer

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -1,9 +1,12 @@
 import { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import { Script } from 'react-loadscript';
 
 import DialogScreen from '../components/DialogScreen';
 import DialogScreen_ViewCamera from '../components/DialogScreen-ViewCamera';
+import MapLegendCameras from '../components/MapLegendCameras';
+import MapLegendVegetation from '../components/MapLegendVegetation';
 const config = require('../../../constants/mapExplorer.config.json');
 const gorongosaGeodata = require('../../../map-data/gorongosa-geodata.json');
 const vegetationGeodata = require('../../../map-data/vegetation-geodata.json');
@@ -127,10 +130,8 @@ class MapVisuals extends Component {
     //Bonus: Add legends to map
     const legend = L.control({position: 'bottomright'});
     legend.onAdd = (map) => {
-      const div = L.DomUtil.create('div', 'info legend');
-      div.innerHTML =
-        '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#666" /></svg> : Camera with no images</div>' +
-        '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#f93" /></svg> : Camera with images (click to view)</div>';
+      let div = L.DomUtil.create('div', '');
+      ReactDOM.render(<MapLegendCameras />, div);
       return div;
     };
     legend.addTo(this.state.map);
@@ -138,12 +139,8 @@ class MapVisuals extends Component {
     //Bonus: Add (vegetation) legends to map
     const vegetationLegend = L.control({position: 'bottomright'});
     vegetationLegend.onAdd = (map) => {
-      const div = L.DomUtil.create('div', 'info legend');
-      div.innerHTML = '<div>Vegetation types</div>';
-      for (let key in vegetationGeodata.specificStyles) {
-        const color = vegetationGeodata.specificStyles[key].color;
-        div.innerHTML += '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="'+color+'" fill-opacity="0.5" /></svg> : '+key+'</div>';
-      }
+      let div = L.DomUtil.create('div', '');
+      ReactDOM.render(<MapLegendVegetation />, div);
       return div;
     };
     vegetationLegend.addTo(this.state.map);


### PR DESCRIPTION
Features
- Gorongosa National Park geodata layer restyled so it's only a border.
- Vegetation geodata layer restyled to support different colours for each terrain type.
  - No new geodata layers added to avoid noisiness on Map Explorer... for now.
- Legend for Vegetation geodata layer added.
- The "Layers" submenu, on the upper right, is now permanently expanded to make it SUPER obvious to users that they can toggle layers.

<img width="1280" alt="screen shot 2016-08-02 at 15 30 56" src="https://cloud.githubusercontent.com/assets/13952701/17333220/751b69ec-58c9-11e6-83ba-16808bc2ef3d.png">
Screen layout on a MacBook Pro (Retina, 13-inch, Early 2015). Also note use of colours; the mountain is pink-ish because I simply ran out of contrasting colours that work at such a low opacity.

Known Issue
- CartoDB Data layer appears below the GeoJSON overlay layers.
- This is because the CartoDB is technically a raster 'tile' layer that is grouped in Leaflet's `tilePane` (together with the base map layer), instead of the 'higher' (z-index-wise) `overlayPane` where the GeoJSON layers appear. So... rearranging them would be impossible unless I move the CartoDB Data layer out  of the `tilePane` group somehow.
- Workaround: GeoJSON overlay layers use visual tricks to make it less obvious that the CartoDB data points are beneath them. (Low opacity, etc)

This PR is ready for review. Improves on closed issue #247 and the 'add layers item' on milestone list #242 
