### PR TITLE
[EXPERIMENTAL] Map Explorer - Use CartoDB as GeoJSON

### DIFF
--- a/src/map-data/gorongosa-geodata.json
+++ b/src/map-data/gorongosa-geodata.json
@@ -9,8 +9,8 @@
   },
   "options": {
     "style": {
-      "color": "#c93",
-      "opacity": 0.5,
+      "color": "#00ff00",
+      "opacity": 1,
       "clickable": false,
       "weight": 5
     }

--- a/src/map-data/gorongosa-geodata.json
+++ b/src/map-data/gorongosa-geodata.json
@@ -9,8 +9,9 @@
   },
   "options": {
     "style": {
-      "color": "#00ff00",
+      "color": "#fc3",
       "opacity": 1,
+      "fillOpacity": 0,
       "clickable": false,
       "weight": 5
     }

--- a/src/map-data/vegetation-geodata.json
+++ b/src/map-data/vegetation-geodata.json
@@ -29,11 +29,11 @@
     "Floodplain Grassland": { "color": "#3c9" },
     "Limestone Gorges": { "color": "#cc0" },
     
-    "Montane Woodland": { "color": "#c00" },
+    "Montane Woodland": { "color": "#c3c" },
     "Montane Forest": { "color": "#606" },
     "Montane Grassland": { "color": "#30c" },
     
     "Lake Urema": { "color": "#0ff" },
-    "Inselberg": { "color": "#c90" }
+    "Inselberg": { "color": "#f30" }
   }
 }

--- a/src/map-data/vegetation-geodata.json
+++ b/src/map-data/vegetation-geodata.json
@@ -16,10 +16,10 @@
   },
   "options": {
     "style": {
-      "color": "#9c6",
-      "opacity": 100,
+      "color": "#0000ff",
+      "opacity": 1,
       "clickable": false,
-      "weight": 0
+      "weight": 1
     }
   }
 }

--- a/src/map-data/vegetation-geodata.json
+++ b/src/map-data/vegetation-geodata.json
@@ -16,10 +16,24 @@
   },
   "options": {
     "style": {
-      "color": "#0000ff",
-      "opacity": 1,
+      "color": "#0f0",
+      "opacity": 0,
+      "fillOpacity": 0.2,
       "clickable": false,
-      "weight": 1
+      "weight": 0
     }
+  },
+  "specificStyles" : {
+    "Miombo Woodland": { "color": "#063" },
+    "Mixed Savanna and Woodland": { "color": "#693" },
+    "Floodplain Grassland": { "color": "#3c9" },
+    "Limestone Gorges": { "color": "#cc0" },
+    
+    "Montane Woodland": { "color": "#c00" },
+    "Montane Forest": { "color": "#606" },
+    "Montane Grassland": { "color": "#30c" },
+    
+    "Lake Urema": { "color": "#0ff" },
+    "Inselberg": { "color": "#c90" }
   }
 }

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -27,9 +27,9 @@ class MapSelector {
     this.user = '';
 
     //Default marker styles.
-    this.markerColor = '#ff0000';  //'#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
+    this.markerColor = '#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
     this.markerSize = '15';
-    this.markerOpacity = '1.0';  //'0.8';
+    this.markerOpacity = '0.8';
 
     //These two are the most important values; they're derived from the selector
     //settings above.

--- a/src/modules/common/containers/MapSelector.jsx
+++ b/src/modules/common/containers/MapSelector.jsx
@@ -27,9 +27,9 @@ class MapSelector {
     this.user = '';
 
     //Default marker styles.
-    this.markerColor = '#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
+    this.markerColor = '#ff0000';  //'#ff9900';  //For... consistency, this is coLOR instead of coLOUR.
     this.markerSize = '15';
-    this.markerOpacity = '0.8';
+    this.markerOpacity = '1.0';  //'0.8';
 
     //These two are the most important values; they're derived from the selector
     //settings above.

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -92,8 +92,8 @@ class MapVisuals extends Component {
     
     //Create the CartoDB Data layer
     cartodb.createLayer(this.state.map, config.cartodb.vizUrl)
-      .addTo(this.state.map)
-      .on('done', (layer) => {
+      .done((layer) => {
+        layer.addTo(this.state.map);
         this.state.cartodbLayer = layer;
         this.state.cartodbLayer.setInteraction(true);
         layer.on('error', (err) => {
@@ -102,14 +102,16 @@ class MapVisuals extends Component {
 
         //Add the controls for the layers
         L.control.layers(baseLayersForControls, {
-          ...geomapLayers,
           'Data': layer,
+          ...geomapLayers
+        }, {
+          'collapsed': false,
         }).addTo(this.state.map);
 
         //updateDataVisualisation performs some cleanup
         this.updateDataVisualisation(this.props);
       })
-      .on('error', (err) => {
+      .error((err) => {
         console.error('ERROR (initMapExplorer(), cartodb.createLayer()):' + err);
       });
 

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -128,12 +128,25 @@ class MapVisuals extends Component {
     const legend = L.control({position: 'bottomright'});
     legend.onAdd = (map) => {
       const div = L.DomUtil.create('div', 'info legend');
-      div.innerHTML +=
+      div.innerHTML =
         '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#666" /></svg> : Camera with no images</div>' +
         '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="#f93" /></svg> : Camera with images (click to view)</div>';
       return div;
     };
     legend.addTo(this.state.map);
+    
+    //Bonus: Add (vegetation) legends to map
+    const vegetationLegend = L.control({position: 'bottomright'});
+    vegetationLegend.onAdd = (map) => {
+      const div = L.DomUtil.create('div', 'info legend');
+      div.innerHTML = '<div>Vegetation types</div>';
+      for (let key in vegetationGeodata.specificStyles) {
+        const color = vegetationGeodata.specificStyles[key].color;
+        div.innerHTML += '<div><svg height="10" width="10"><circle cx="5" cy="5" r="5" fill="'+color+'" fill-opacity="0.5" /></svg> : '+key+'</div>';
+      }
+      return div;
+    };
+    vegetationLegend.addTo(this.state.map);
 
     //Bonus: 'Recentre Map' button
     const recentreButton = L.control({position: 'topleft'});

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -179,12 +179,38 @@ class MapVisuals extends Component {
     for (let i = this.state.cartodbLayer.getSubLayerCount() - 1; i >= 0; i--) {
       this.state.cartodbLayer.getSubLayer(i).remove();
     }
-
+    
     //Add a new sublayer for each selector
     props.selectors.map((selector) => {
       let sql = selector.sql.trim();
       let css = selector.css.trim();
       if (sql !== '' && css !== '') {
+        
+        //TEST
+        //--------------------------------
+        let cartoSql = cartodb.SQL({user: 'shaunanoordin-zooniverse', format: 'geojson'});
+        cartoSql.execute(sql)
+        .done((geojson) => {
+          console.log('!'.repeat(80));
+          console.log(geojson);          
+          L.geoJson(geojson, {
+            pointToLayer: function (feature, latlng) {
+              const marker = L.circleMarker(latlng, {
+                color: '#f00',
+                fillColor: '#f00',
+                fillOpacity: 1,
+                radius: '100'
+              });
+              marker.on('click', (e) => {
+                alert('CLICK!');
+              });
+              
+              return marker;
+            }
+          }).addTo(this.state.map);
+        });
+        //--------------------------------
+        
         let newSubLayer = this.state.cartodbLayer.createSubLayer({
           sql: sql,
           cartocss: css,

--- a/src/modules/common/containers/MapVisuals.jsx
+++ b/src/modules/common/containers/MapVisuals.jsx
@@ -87,7 +87,16 @@ class MapVisuals extends Component {
     //Create the CartoDB Geomap layer
     const geomapLayers = {
       'Gorongosa National Park': L.geoJson(gorongosaGeodata.geojson, gorongosaGeodata.options).addTo(this.state.map),
-      'Vegetation': L.geoJson(vegetationGeodata.geojson, vegetationGeodata.options).addTo(this.state.map),
+      'Vegetation': L.geoJson(vegetationGeodata.geojson, {
+        style: function (feature) {
+          const specificStyles = vegetationGeodata.specificStyles;
+          let baseStyle = vegetationGeodata.options.style;
+          const featureName = feature.properties.NAME;
+          return (specificStyles[featureName])
+            ? Object.assign(baseStyle, specificStyles[featureName])
+            : baseStyle;
+        }        
+      }).addTo(this.state.map),
     };
     
     //Create the CartoDB Data layer


### PR DESCRIPTION
Currently we have CartoDB as a Tile Layer in Leaflet. This has caused some... unique problems esp. in regards to the layering order with the new GeoJSON data, which appears on top of all tile layers.

GOOD NEWS! We can now retrieve the CartoDB data as GeoJSON data.

I've talked to Stuart of CartoDB about this (thanks dude!) and with only 200 POI markers at max (we have about that many cameras), we shouldn't run into any performance issues between raster (tile layer) vs vector (GeoJSON overlay)
