### PR TITLE
Fixes #233

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^2.3.0",
     "nib": "^1.1.0",
-    "panoptes-client": "2.2.1",
+    "panoptes-client": "^2.2.1",
     "publisssh": "^1.0.1",
     "react-a11y": "^0.3.2",
     "react-addons-test-utils": "^0.14.3",

--- a/src/modules/common/actions/login.js
+++ b/src/modules/common/actions/login.js
@@ -1,4 +1,3 @@
-import auth from 'panoptes-client/lib/auth';
 import oauth from 'panoptes-client/lib/oauth';
 
 import * as types from '../../../constants/actionTypes';
@@ -8,7 +7,7 @@ import config from '../../../constants/config';
 // Action creators
 export function checkLoginUser() {  //First thing on app load - check if the user is logged in.
   return (dispatch) => {
-    auth.checkCurrent()
+    oauth.checkCurrent()
       .then(user => {
         dispatch(setLoginUser(user));
       });


### PR DESCRIPTION
Uses `oauth` module for checking current user.
Reinstate the caret versioning for PJC.
Closes #233
