### PR TITLE
Update Footer with partner credits/acknowledgements 

### DIFF
--- a/src/modules/common/components/Layout.jsx
+++ b/src/modules/common/components/Layout.jsx
@@ -78,7 +78,9 @@ class Layout extends Component {
         </main>
 
         <footer className='site-footer'>
-          <p className='pull-left'><a href="https://www.zooniverse.org/" target="_blanket">Zooniverse.org</a> The universe is too big to explore without you</p>
+          <p className='pull-left'>
+            Powered by the <a href="https://www.zooniverse.org/" target="_blank">Zooniverse</a>, mapped by <a href="https://carto.com/" target="_blank">Carto</a> and built in partnership with <a href="https://www.hhmi.org/" target="_blank">HHMI</a>.
+          </p>
           <p className='pull-right'>2016</p>
         </footer>
 


### PR DESCRIPTION
- Simple text change to the Footer to reflect Zooniverse's partnership with HHMI and Carto in building WildCam Labs. Links open a new tab to the respective organisation's website.

![screen shot 2016-08-25 at 16 41 32](https://cloud.githubusercontent.com/assets/13952701/17975786/f3ec8528-6ae2-11e6-97e8-6993a15d5a71.png)

Status: Ready for review
