### PR TITLE
Added "Easy Mode Special Values" for CSVs

### DIFF
--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -37,6 +37,10 @@
       "most_likely_are_there_any_young_present": "young_present",
       "percentage_do_you_see_any_hornsyes": "horns",
       "location": "image_url"
+    },
+    "csvEasyModeSpecialValues": {
+      "11-50": "25",
+      "51+": "75"
     }
   },
   "mapCentre": {

--- a/src/modules/common/components/SuperDownloadButton.jsx
+++ b/src/modules/common/components/SuperDownloadButton.jsx
@@ -118,7 +118,8 @@ class SuperDownloadButton extends Component {
     //Prepare the column headers
     //NOTE: we can package these translations into the SQL query but it'll get super long & messy
     for (let key in mapconfig.cartodb.csvEasyModeTranslator) {
-      row.push('"'+mapconfig.cartodb.csvEasyModeTranslator[key].replace(/"/g, '\\"')+'"');
+      let thisVal = '"'+mapconfig.cartodb.csvEasyModeTranslator[key].replace(/"/g, '\\"')+'"'
+      row.push(thisVal);
     }
     row = row.join(',');
     data.push(row);
@@ -127,9 +128,15 @@ class SuperDownloadButton extends Component {
     json.rows.map((rowItem) => {
       let row = [];
       for (let key in mapconfig.cartodb.csvEasyModeTranslator) {
-        (json.fields[key].type === 'string' && rowItem[key])
-          ? row.push('"'+rowItem[key].replace(/"/g, '\\"')+'"')
-          : row.push(rowItem[key]);
+        let thisVal = rowItem[key];
+        
+        if (mapconfig.cartodb.csvEasyModeSpecialValues[thisVal]) {
+          //Teacher & Students using Excel are confused when seeing the range "11-50" and "51+"; these speical values will be translated to "25" and "75"
+          thisVal = mapconfig.cartodb.csvEasyModeSpecialValues[thisVal];
+        }
+        (json.fields[key].type === 'string' && thisVal)
+          ? row.push('"'+thisVal.replace(/"/g, '\\"')+'"')
+          : row.push(thisVal);
       }
       row = row.join(',');
       data.push(row);

--- a/src/modules/students/components/Tutorial-Students.jsx
+++ b/src/modules/students/components/Tutorial-Students.jsx
@@ -37,6 +37,7 @@ const TutorialForStudents = (props) => (
       <li>Click “Download” and select the destination folder for the file. Click “Save.”</li>
       <li>The downloaded file is in CSV (comma separated values) format. Files of this format can be opened in Microsoft Excel by double-clicking the file. If the file does not automatically open in Excel, open Excel, click File>Open, and select the CSV file from your computer. </li>
       <li>If you wish to convert the CSV file to an Excel file (.xls), open the CSV file in Excel and click File>Save as. In the format dropdown, select Excel 97-2004 Workbook (.xls).</li>
+      <li>Please note that when viewing the species count for large numbers of animals, the number "25" actually corresponds to the range of "11-50" animals, and the number "75" actually corresponds to the range of "50+" animals. While the research data uses numerical range groups to distinguish large amounts of animals, the downloaded CSV takes the mean values to allow you to use species counts in calculations and graphs.</li>
     </ul>
 
   </div>

--- a/src/modules/teachers/components/Tutorial-Teachers.jsx
+++ b/src/modules/teachers/components/Tutorial-Teachers.jsx
@@ -54,6 +54,7 @@ const TutorialForTeachers = (props) => (
       <li>The downloaded file is in CSV (comma separated values) format. Files of this format can be opened in Microsoft Excel by double-clicking the file. If the file does not automatically open in Excel, open Excel, click File>Open, and select the CSV file from your computer. </li>
       <li>If you wish to convert the CSV file to an Excel file (.xls), open the CSV file in Excel and click File>Save as. In the format dropdown, select Excel 97-2004 Workbook (.xls).</li>
       <li>You can share data sets that you curate for students, or you can instruct students to explore the map, filter, and download data on their own.</li>
+      <li>Please note that when viewing the species count for large numbers of animals, the number "25" actually corresponds to the range of "11-50" animals, and the number "75" actually corresponds to the range of "50+" animals. While the research data uses numerical range groups to distinguish large amounts of animals, the downloaded CSV takes the mean values to allow you to use species counts in calculations and graphs.</li>
     </ul>
 
   </div>


### PR DESCRIPTION
## Overview

Fixes #303 

When downloading CSVs, the values "11-50" and "51+" (i.e. very large species counts) are considered special values. They'll be translated to 25 and 75 respectively. This is to allow Teachers and Students (particularly those using Excel) to use "proper" numerical values to, e.g. create charts and graphs
## Status

In Progress.

Need to add Caveats and Warnings for users.
