### PR TITLE
Improve 'Create Assignment' process with better messaging

### DIFF
--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -331,13 +331,9 @@ class AssignmentForm extends Component {
           ? <div className="form-group" style={{overflow: 'hidden'}}>
               <div className="pull-right"><Spinner /></div>
             </div>
-          : null
-        }
-        {(!this.state.loading && savedSubjectsIDs.length > 0)
-          ? <div className="form-group" style={{overflow: 'hidden'}}>
+          : <div className="form-group" style={{overflow: 'hidden'}}>
               <button type="submit" className="btn btn-primary pull-right">Submit</button>
             </div>
-          : null
         }
       </form>
     );

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -313,16 +313,16 @@ class AssignmentForm extends Component {
         <div className="form-group">
           {this.renderSelectedSubjects()}
         </div>
-        {(savedSubjectsIDs.length === 0 && !this.state.loading && !(this.props.fields && this.props.fields.subjects))
+        {(savedSubjectsIDs.length === 0 && !this.state.loading && !this.editMode())
           ? <div className="form-group">
               <p>You need to select images for this assignment. Click "Select images" below, then use the map to choose a set of images for your students to identify and click "Select for assignment". </p>
               <button className="btn btn-primary" disabled={this.editMode()} onClick={this.selectNewSubjects}>Select images</button>
             </div>
           : null
         }
-        {(savedSubjectsIDs.length > 0 && !this.state.loading && !(this.props.fields && this.props.fields.subjects))
+        {(savedSubjectsIDs.length > 0 && !this.state.loading && !this.editMode())
           ? <div className="form-group">
-              <p>You've already selected images for this assignment. If you wish to replace them with newer images, click the "Select new images". Otherwise, click "Submit" to create the assignment.</p>
+              <p>If you wish to replace your chosen images with newer images, click the "Select new images". Otherwise, click "Submit" to create the assignment.</p>
               <button className="btn btn-default" disabled={this.editMode()} onClick={this.selectNewSubjects}>Select new images</button>
             </div>
           : null

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -260,6 +260,9 @@ class AssignmentForm extends Component {
       ? classrooms.uniqueMembers
           .filter(student => currentStudentsIds.includes(student.id))
       : {};
+    let savedSubjectsIDs = sessionStorage.getItem('savedSubjectsIDs');
+    savedSubjectsIDs = (savedSubjectsIDs === null || savedSubjectsIDs === '') ?
+      [] : savedSubjectsIDs.split(',');
     return (
       <form onSubmit={this.handleSubmit}>
         <h3>Classroom {currentClassroom ? currentClassroom.attributes.name : 'Loading'}</h3>
@@ -310,16 +313,32 @@ class AssignmentForm extends Component {
         <div className="form-group">
           {this.renderSelectedSubjects()}
         </div>
-        <div className="form-group">
-          <p>Use the map to choose a set of images for your students to identify and "Select for assignment". </p>
-          <button className="btn btn-default" disabled={this.editMode()} onClick={this.selectNewSubjects}>Select images</button>
-        </div>
-        <div className="form-group" style={{overflow: 'hidden'}}>
-          {(!this.state.loading)
-            ? <button type="submit" className="btn btn-primary pull-right">Submit</button>
-            : <div className="pull-right"><Spinner /></div>
-          }
-        </div>
+        {(savedSubjectsIDs.length === 0 && !this.state.loading && !(this.props.fields && this.props.fields.subjects))
+          ? <div className="form-group">
+              <p>You need to select images for this assignment. Click "Select images" below, then use the map to choose a set of images for your students to identify and click "Select for assignment". </p>
+              <button className="btn btn-primary" disabled={this.editMode()} onClick={this.selectNewSubjects}>Select images</button>
+            </div>
+          : null
+        }
+        {(savedSubjectsIDs.length > 0 && !this.state.loading && !(this.props.fields && this.props.fields.subjects))
+          ? <div className="form-group">
+              <p>You've already selected images for this assignment. If you wish to replace them with newer images, click the "Select new images". Otherwise, click "Submit" to create the assignment.</p>
+              <button className="btn btn-default" disabled={this.editMode()} onClick={this.selectNewSubjects}>Select new images</button>
+            </div>
+          : null
+        }
+        {(this.state.loading)
+          ? <div className="form-group" style={{overflow: 'hidden'}}>
+              <div className="pull-right"><Spinner /></div>
+            </div>
+          : null
+        }
+        {(!this.state.loading && savedSubjectsIDs.length > 0)
+          ? <div className="form-group" style={{overflow: 'hidden'}}>
+              <button type="submit" className="btn btn-primary pull-right">Submit</button>
+            </div>
+          : null
+        }
       </form>
     );
   }

--- a/src/modules/teachers/components/AssignmentForm.jsx
+++ b/src/modules/teachers/components/AssignmentForm.jsx
@@ -2,6 +2,7 @@ import { Component, PropTypes } from 'react';
 import { Link, browserHistory } from 'react-router';
 
 import InputElement from './InputElement';
+import Spinner from '../../common/components/Spinner';
 
 const initialState = {
   classifications_target: '',
@@ -313,8 +314,11 @@ class AssignmentForm extends Component {
           <p>Use the map to choose a set of images for your students to identify and "Select for assignment". </p>
           <button className="btn btn-default" disabled={this.editMode()} onClick={this.selectNewSubjects}>Select images</button>
         </div>
-        <div className="form-group">
-          <button type="submit" disabled={this.state.loading} className="btn btn-primary pull-right">Submit</button>
+        <div className="form-group" style={{overflow: 'hidden'}}>
+          {(!this.state.loading)
+            ? <button type="submit" className="btn btn-primary pull-right">Submit</button>
+            : <div className="pull-right"><Spinner /></div>
+          }
         </div>
       </form>
     );

--- a/src/styles/components/dialog-ver3.styl
+++ b/src/styles/components/dialog-ver3.styl
@@ -26,8 +26,7 @@
     border-radius: 1em
     cursor: default
     box-shadow: 0 2px 10px dark-grey
-    width: 90%
-    max-width: 1000px
+    max-width: 90vw
     max-height: 90vh
     overflow: auto
     
@@ -116,7 +115,7 @@
     
       .image
         display: block
-        max-width: 40%
+        max-width: 80%
         margin: 0 auto 1em auto
         border-radius: 1em
         box-shadow: 0 0.2em 0.5em dark-grey
@@ -135,7 +134,7 @@
         color: dark-grey
         box-shadow: 0 0.2em 0.5em light-grey
         text-align: left
-        width: 60%
+        width: 80%
         min-width: 400px
         border-radius: 0.5em
         


### PR DESCRIPTION
## PR Overview
The Create Assignment process needs better messaging so Teachers can better understand what's happening at every stage of the process, and what they need to do next. 

Notable changes in this PR are:
* The Create Assignment page tells users if they need to Select Images (if they haven't already) or if they can Select New Images (if they have images already)
* The View/Edit Assignment page has been changed so "Use the map to choose a set of images for your students to identify..." message no longer appears (because users can't choose new images)
* When submitting the Create/Edit Assignment request, the Submit button now turns into the spinning cog icon. 
* Aside: the tutorial for Educators & Students have somewhat improved CSS, to allow for larger tutorial images.

## PR Details

![screen shot 2016-11-22 at 16 42 01](https://cloud.githubusercontent.com/assets/13952701/20532922/a6ba7f94-b0d3-11e6-9cdc-ee1b9cc0c163.png)
Create Assignment: when user is just creating an Assignment, the "Select Images" button becomes a bit more clear.

![screen shot 2016-11-22 at 16 42 14](https://cloud.githubusercontent.com/assets/13952701/20532941/b55a3e2c-b0d3-11e6-88c0-6b1247e3c675.png)
Create Assignment: when user has already selected images for the Assignment, the message for "Select Images" changes accordingly.

![screen shot 2016-11-22 at 16 42 20](https://cloud.githubusercontent.com/assets/13952701/20532971/cc21c7d8-b0d3-11e6-83f0-2a20ead08feb.png)
Create Assignment: when submitting the Assignment to the Education API server, the Submit buttons turns into an "I'm loading..." spinning icon.

![screen shot 2016-11-22 at 16 42 32](https://cloud.githubusercontent.com/assets/13952701/20533021/f7b00b6c-b0d3-11e6-8c1a-3f498b17a12f.png)
View/Edit Assignment: when viewing an existing Assignment, the inappropriate "Select Images" messages disappears altogether.

## Status
Ready for review