### PR TITLE
Fix Edit Assignment: remember filter and subjects

### DIFF
--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -120,11 +120,12 @@ export function editAssignment(fields, assignment) {
       attributes: {
         name: fields.name,
         metadata: {
-          description: fields.description,
           classifications_target: fields.classifications_target,
+          description: fields.description,
           duedate: fields.duedate,
-          filters: fields.filters,
-        },
+          filters:  (assignment.attributes && assignment.attributes.metadata) ? (assignment.attributes.metadata.filters)  : null,
+          subjects: (assignment.attributes && assignment.attributes.metadata) ? (assignment.attributes.metadata.subjects) : null,
+        }
       },
       relationships: {
         student_users: {


### PR DESCRIPTION
## PR Overview
* Currently when a Teacher edits an Assignment, the filters they used and the number of subjects they selected (metadata info which was set when the Assignment was created) is lost.
* This PR fixes the metadata that's submitted to the Education API.

## Status
Ready for review.