### PR TITLE
Use new Map Providers

### DIFF
--- a/src/constants/mapExplorer.config.json
+++ b/src/constants/mapExplorer.config.json
@@ -51,13 +51,28 @@
   "baseLayers": [
     {
       "name": "Terrain",
-      "url": "//{s}.tile.thunderforest.com/landscape/{z}/{x}/{y}.png",
-      "attribution": "&copy; <a href=\"http://www.opencyclemap.org\">OpenCycleMap</a>, &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+      "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+      "attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community"
+    },
+    {
+      "name": "Terrain (Shaded)",
+      "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}",
+      "attribution": "Tiles &copy; Esri &mdash; Source: Esri"
+    },
+    {
+      "name": "Roads",
+      "url": "http://{s}.tiles.wmflabs.org/hikebike/{z}/{x}/{y}.png",
+      "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
     },
     {
       "name": "Satellite",
       "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
       "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+    },
+    {
+      "name": "Plain",
+      "url": "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+      "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>"
     }
   ],
   "species": [


### PR DESCRIPTION
## PR Overview
* Fixes #319 
* Removes Thunderforest's OpenCycle map (labelled "Terrain") which now requires a paid subscription/API key to use.
* Adds four new maps to the Map Explorer in its stead.
  * To see them, click on the "layers" button on the left hand side of the map, and see the new list of five map options: _new_ Terrain, Terrain (shaded), Roads, _same old_ Satellite and Plain 