### PR TITLE
Program filter and assignment create update

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "chai"
   ],
   "scripts": {
-    "start": "babel-node server.js",
+    "start": "NODE_ENV=staging; babel-node server.js",
     "build": "webpack --config webpack.production.config.js -p",
     "test": "mocha --reporter nyan --compilers js:babel/register --recursive",
-    "deploy-preview": "npm run build && publisssh dist zooniverse-static/preview.zooniverse.org/wge",
-    "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/lab.wildcamgorongosa.org"
+    "deploy-preview": "NODE_ENV=staging; npm run build && publisssh dist zooniverse-static/preview.zooniverse.org/wge",
+    "deploy-production": "NODE_ENV=production; npm run build && publisssh dist zooniverse-static/lab.wildcamgorongosa.org"
   },
   "license": "Apache-2.0",
   "bugs": {

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -41,7 +41,8 @@ const envConfig = {
   staging: {
     eduAPI: {
       root:'https://education-api-staging.zooniverse.org/',
-      programId: '4'
+      programId: '4',
+      workflowId: '338' // WG doesn't exist on staging, so this is the production default workflow id
     },
     routes: {
       root:'http://localhost:3000/'
@@ -52,7 +53,8 @@ const envConfig = {
   production: {
     eduAPI: {
       root: 'https://education-api.zooniverse.org/',
-      programId: '' // TODO add program id for wildcam gorongosa when it exists in production
+      programId: '', // TODO add program id for wildcam gorongosa when it exists in production
+      workflowId: '338'
     },
     routes: {
       root: 'https://lab.wildcamgorongosa.org/'

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -42,7 +42,10 @@ const envConfig = {
     eduAPI: {
       root:'https://education-api-staging.zooniverse.org/',
       programId: '4',
-      workflowId: '338' // WG doesn't exist on staging, so this is the production default workflow id
+      // We used hard coded sample subject ids because the Carto DB is only for production
+      // These are used in the assignment creation in development so that the POST works
+      sampleSubjects: ['37763', '37755', '37767'],
+      workflowId: '1549' // Linked to staging project 937
     },
     routes: {
       root:'http://localhost:3000/'
@@ -54,6 +57,7 @@ const envConfig = {
     eduAPI: {
       root: 'https://education-api.zooniverse.org/',
       programId: '', // TODO add program id for wildcam gorongosa when it exists in production
+      sampleSubjects: [],
       workflowId: '338'
     },
     routes: {

--- a/src/modules/students/actions/index.js
+++ b/src/modules/students/actions/index.js
@@ -51,7 +51,7 @@ export function fetchStudentClassrooms() {
     dispatch({
       type: types.REQUEST_STUDENT_CLASSROOMS,
     });
-    return fetch(config.eduAPI.root + config.eduAPI.students, {
+    return fetch(config.eduAPI.root + config.eduAPI.students + `?program_id=${config.eduAPI.programId}`, {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({

--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -7,7 +7,7 @@ import * as types from '../../../constants/actionTypes';
 
 
 // Action creators
-const { root, assignments } = config.eduAPI;
+const { root, assignments, workflowId } = config.eduAPI;
 
 export function createAssignment(assignment, classroomId) {
   const classroomData = {
@@ -29,12 +29,13 @@ export function createAssignment(assignment, classroomId) {
     id: subject_id,
     type: 'subjects',
   }));
-  
+
   const bodyData = JSON.stringify({
     data: {
       attributes: {
         name: assignment.name,
         metadata,
+        workflow_id: workflowId
       },
       relationships: {
         classroom: {
@@ -109,12 +110,12 @@ export function deleteAssignment(assignmentId, classroomId) {
 }
 
 export function editAssignment(fields, assignment) {
-  
+
   let studentData = fields.students.map(student_id => ({
     id: student_id,
     type: 'student_user',
   }));
-  
+
   const bodyData = JSON.stringify({
     data: {
       attributes: {
@@ -134,7 +135,7 @@ export function editAssignment(fields, assignment) {
       },
     }
   });
-  
+
   return dispatch => {
     dispatch({
       ...fields,

--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -2,7 +2,7 @@ import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch';
 import apiClient from 'panoptes-client/lib/api-client';
 
-import config from '../../../constants/config';
+import config, { env } from '../../../constants/config';
 import * as types from '../../../constants/actionTypes';
 
 
@@ -22,7 +22,7 @@ export function createAssignment(assignment, classroomId) {
   }));
 
   // Carto DB doesn't have staging data. We use hard coded subject ids from the staging WG project and ignore the Carto selection.
-  if (process.env.NODE_ENV === 'staging') {
+  if (env === 'staging' || env === 'development') {
     subjectData = sampleSubjects.map((subject_id) => ({
       id: subject_id,
       type: 'subjects',

--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -23,8 +23,6 @@ export function createAssignment(assignment, classroomId) {
 
   // Carto DB doesn't have staging data. We use hard coded subject ids from the staging WG project and ignore the Carto selection.
   if (process.env.NODE_ENV === 'staging') {
-    console.log(process.env.NODE_ENV, 'staging!')
-
     subjectData = sampleSubjects.map((subject_id) => ({
       id: subject_id,
       type: 'subjects',
@@ -38,7 +36,6 @@ export function createAssignment(assignment, classroomId) {
       subjects: sampleSubjects,
     };
   } else {
-    console.log('else')
     subjectData = assignment.subjects.map(subject_id => ({
       id: subject_id,
       type: 'subjects',
@@ -52,7 +49,6 @@ export function createAssignment(assignment, classroomId) {
       subjects: assignment.subjects,
     };
   }
-  console.log('subjectData', subjectData)
 
   const bodyData = JSON.stringify({
     data: {

--- a/src/modules/teachers/actions/assignment.js
+++ b/src/modules/teachers/actions/assignment.js
@@ -7,28 +7,52 @@ import * as types from '../../../constants/actionTypes';
 
 
 // Action creators
-const { root, assignments, workflowId } = config.eduAPI;
+const { root, assignments, sampleSubjects, workflowId } = config.eduAPI;
 
 export function createAssignment(assignment, classroomId) {
+  let subjectData = [];
+  let metadata;
   const classroomData = {
     id: classroomId,
     type: 'classrooms',
-  };
-  const metadata = {
-    classifications_target: assignment.classifications_target,
-    description: assignment.description,
-    duedate: assignment.duedate,
-    filters: assignment.filters,
-    subjects: assignment.subjects,
   };
   const studentData = assignment.students.map(student_id => ({
     id: student_id,
     type: 'student_user',
   }));
-  const subjectData = assignment.subjects.map(subject_id => ({
-    id: subject_id,
-    type: 'subjects',
-  }));
+
+  // Carto DB doesn't have staging data. We use hard coded subject ids from the staging WG project and ignore the Carto selection.
+  if (process.env.NODE_ENV === 'staging') {
+    console.log(process.env.NODE_ENV, 'staging!')
+
+    subjectData = sampleSubjects.map((subject_id) => ({
+      id: subject_id,
+      type: 'subjects',
+    }));
+
+    metadata = {
+      classifications_target: assignment.classifications_target,
+      description: assignment.description,
+      duedate: assignment.duedate,
+      filters: assignment.filters,
+      subjects: sampleSubjects,
+    };
+  } else {
+    console.log('else')
+    subjectData = assignment.subjects.map(subject_id => ({
+      id: subject_id,
+      type: 'subjects',
+    }));
+
+    metadata = {
+      classifications_target: assignment.classifications_target,
+      description: assignment.description,
+      duedate: assignment.duedate,
+      filters: assignment.filters,
+      subjects: assignment.subjects,
+    };
+  }
+  console.log('subjectData', subjectData)
 
   const bodyData = JSON.stringify({
     data: {

--- a/src/modules/teachers/actions/teacher.js
+++ b/src/modules/teachers/actions/teacher.js
@@ -7,7 +7,7 @@ import * as types from '../../../constants/actionTypes';
 
 
 // Action creators
-const { root, teachers } = config.eduAPI;
+const { root, teachers, programId } = config.eduAPI;
 
 export function createClassroom(classroom) {
   return dispatch => {
@@ -22,7 +22,15 @@ export function createClassroom(classroom) {
       }),
       body: JSON.stringify({
         data: {
-          attributes: classroom
+          attributes: classroom,
+          relationships: {
+            program: {
+              data: {
+                id: programId,
+                type: 'programs'
+              }
+            }
+          }
         }
       })
     })
@@ -73,7 +81,7 @@ export function fetchClassrooms() {
     dispatch({
       type: types.REQUEST_CLASSROOMS,
     });
-    return fetch(root + teachers, {
+    return fetch(root + teachers + `?program_id=${programId}`, {
       method: 'GET',
       mode: 'cors',
       headers: new Headers({


### PR DESCRIPTION
This updates the WG:L for the current API:

- Classroom GET requests are now filtered by program
- Links the classroom to the WG program on classroom create
- Assignment creation uses a workflow id
  - In the staging environment, the assignment creation uses WG project on staging and a hard coded set of subject ids. This is because the Carto DB data is only for production.

The assignment creation still isn't fully testable because as noted on slack, there's still an issue with the POST request failing permissions with Panoptes, however, the code itself could be reviewed in the interim.