### PR TITLE
Fix Student Assignment links

### DIFF
--- a/src/modules/students/components/ClassroomAssignments.jsx
+++ b/src/modules/students/components/ClassroomAssignments.jsx
@@ -41,6 +41,9 @@ class ClassroomAssignments extends Component {
     return (
     <div className="student-assignmentlist">
       <h1>Assignments</h1>
+      <div className="notice">
+        Please make sure that you first Sign In at <a href="https://www.wildcamgorongosa.org/" target="_blank" rel="noreferrer noopener">www.wildcamgorongosa.org</a> with the same account before starting an Assignment.
+      </div>
       { data.map(classroom =>
         <section key={ classroom.classroom_id }>
           <h3>Classroom { classroom.classroom_name }</h3>

--- a/src/modules/students/components/ClassroomAssignments.jsx
+++ b/src/modules/students/components/ClassroomAssignments.jsx
@@ -63,7 +63,7 @@ class ClassroomAssignments extends Component {
                 <td>{ assignment.classification_count }/{ assignment.target }</td>
                 <td>
                   <a className="btn btn-primary"
-                    href={`https://www.wildcamgorongosa.org/#/classify/assignment-${ assignment.id }/access_token=${ token.access_token }`}
+                    href={`https://www.wildcamgorongosa.org/#/classify/assignment-${ assignment.id }`}
                     target="_blank"
                     role="button">
                     Start assignment

--- a/src/styles/components/student-assignmentlist.styl
+++ b/src/styles/components/student-assignmentlist.styl
@@ -4,6 +4,15 @@
   padding: 0 2em
   margin: 0 auto
   background-color: rgba(216,216,216,0.6)
+  
+  .notice
+    background: yellow
+    border-radius: 0.5em
+    padding: 1em
+    font-size: 0.8em
+    
+    a
+      color: green
 
   .btn
     display: block


### PR DESCRIPTION
## PR Overview
This PR fixes(?) the URLs given to Students for their Assignments.
- Also, a notice has been added to the Students Assignments page reminding them to Sign In at `www.wildcamgorongosa.org`

At the moment, Assignments URLs Students see in the Assignments page (`/students/assignments -> [Start Assignment]`) look like this:
`https://www.wildcamgorongosa.org/#/classify/assignment-123/access_token=abcdefghijklmnop`

This URL unfortunately seems to break; `wildcamgorongosa.org` does not route the `/access_token=abcde` portion in any sensible way.

The URL that _works_ should instead be...
`https://www.wildcamgorongosa.org/#/classify/assignment-123`

Problem is, I'm not entirely sure what the `access_token` was originally added for, and if there are any repercussions for taking this out. Assignments on WildCam Gorongosa work properly even with the `access_token` removed, but I need to monitor for any weirdness that I didn't plan for.

### Status
Merging and deploying, with a hint of caution.

Tagging @mrniaboc to make sure I stay responsible.